### PR TITLE
Add support for a custom Tushare API URL, and update the environment variable loader and example configuration

### DIFF
--- a/bullet_trade/data/providers/tushare.py
+++ b/bullet_trade/data/providers/tushare.py
@@ -18,6 +18,7 @@ class TushareProvider(DataProvider):
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         self.config = config or {}
         self._token = self.config.get("token") or os.getenv("TUSHARE_TOKEN")
+        self._tushare_custom_url = self.config.get("tushare_custom_url") or os.getenv("TUSHARE_CUSTOM_URL")
         cache_dir_set = "cache_dir" in self.config
         cache_dir = self.config.get("cache_dir")
         self._cache = CacheManager(
@@ -84,14 +85,18 @@ class TushareProvider(DataProvider):
         host: Optional[str] = None,
         port: Optional[int] = None,
     ) -> None:
-        _ = host, port, pwd  # tushare 不使用这些字段
+        _ = port, pwd  # tushare 不使用这些字段
         token = user or self._token
         if not token:
             raise RuntimeError("Tushare token 未配置，请设置 TUSHARE_TOKEN 或在 auth 中手动传入")
         ts = self._ensure_ts_module()
         self._pro = ts.pro_api(token)
         self._token = token
-
+        # 支持自定义 API URL
+        tushare_custom_url = host or self._tushare_custom_url
+        if tushare_scustom_url:
+            self._pro._DataApi__http_url = tushare_custom_url
+            print("使用自定义的URL")
     # ------------------------ K 线数据 ------------------------
     def get_price(
         self,

--- a/bullet_trade/utils/env_loader.py
+++ b/bullet_trade/utils/env_loader.py
@@ -161,6 +161,7 @@ def get_data_provider_config() -> dict:
         'tushare': {
             'token': get_env('TUSHARE_TOKEN'),
             'cache_dir': cache_dir_for('tushare'),
+            'tushare_custom_url': get_env('TUSHARE_CUSTOM_URL'),
         },
         'qmt': {
             'host': get_env('QMT_HOST', '127.0.0.1'),
@@ -170,6 +171,7 @@ def get_data_provider_config() -> dict:
             'market': get_env('MINIQMT_MARKET'),
             'cache_dir': cache_dir_for('miniqmt'),
             'tushare_token': get_env('TUSHARE_TOKEN'),
+            'tushare_custom_url': get_env('TUSHARE_CUSTOM_URL'),
         },
         'remote_qmt': {
             'host': get_env('QMT_SERVER_HOST'),

--- a/env.backtest.example
+++ b/env.backtest.example
@@ -22,6 +22,7 @@ JQDATA_PORT=                   # 可选：端口
 # Tushare 配置（可选，需要token）
 # 注册地址: https://tushare.pro/
 # TUSHARE_TOKEN=your_token_here
+# TUSHARE_CUSTOM_URL=tushare_custom_url_if_needed
 
 # MiniQMT (可选，本地 QMT 行情)
 #QMT_DATA_PATH=C:\国金QMT交易端模拟\userdata_mini


### PR DESCRIPTION
Some platforms provide TuShare APIs through self-hosted third-party services, which may not be directly compatible with the official endpoint. This PR introduces a small change to support customizing the TuShare API URL, enabling compatibility with such setups.