### PR TITLE
[WIP] Fix load_env

### DIFF
--- a/bullet_trade/__init__.py
+++ b/bullet_trade/__init__.py
@@ -20,7 +20,8 @@ except Exception as exc:  # pragma: no cover - 兼容运行环境缺少 GUI 依�
 
 # 加载环境变量
 from .utils.env_loader import load_env
-load_env()
+import os
+load_env(os.getenv("ENV_FILE", ".env"), verbose=True)
 
 # 配置中文字体显示
 # from .utils.font_config import setup_chinese_fonts

--- a/bullet_trade/utils/env_loader.py
+++ b/bullet_trade/utils/env_loader.py
@@ -331,4 +331,4 @@ def get_live_trade_config() -> dict:
 
 # 自动加载环境变量
 if __name__ != "__main__":
-    load_env()
+    load_env(os.getenv("ENV_FILE", ".env"), verbose=True)


### PR DESCRIPTION
有些类在用户导入bullet_trade的模块时就实例化了，比如`bullet_trade/__init__.py`里面的`from .data.api import * `通过`_provider: DataProvider = _create_provider()`实例化了data_provider。此时并不能获取`--env-file`指定的env_file，于是只能读取默认的.env，如果.env不存在，就会使用系统默认值。`--env-file`在main运行时才能获取，此时有些类已经通过默认的.env完成实例化。

作者可以看看有没有更加优雅的办法，这个修复有点hack，通过提前注入`ENV_FILE`环境变量，使上述过程能获取到用户指定的env_file。

在启动脚本指定`ENV_FILE`环境变量即可，例如：
```bash
export ENV_FILE='.env.backtest'

bullet-trade \
   --env-file ${ENV_FILE} \
   backtest joinquant_strategies.py \
   --start ${start_date} \
   --end ${end_date} \
   --output backtest_results \
   --cash 1_000_000 \
   --frequency day \
```