### PR TITLE
Add force to run_weekly and run_monthly

### DIFF
--- a/bullet_trade/core/async_engine.py
+++ b/bullet_trade/core/async_engine.py
@@ -128,14 +128,16 @@ class AsyncBacktestEngine(BacktestEngine):
                     task.func,
                     task.weekday,
                     task.time,
-                    overlap_strategy
+                    overlap_strategy,
+                    force=getattr(task, 'force', False),
                 )
             elif task.schedule_type.value == 'monthly':
                 self.async_scheduler.run_monthly(
                     task.func,
                     task.monthday,
                     task.time,
-                    overlap_strategy
+                    overlap_strategy,
+                    force=getattr(task, 'force', False),
                 )
             
             log.debug(
@@ -211,6 +213,7 @@ class AsyncBacktestEngine(BacktestEngine):
 
         # 设置回测频率到 settings，供调度解析使用
         set_option('backtest_frequency', self.frequency)
+        set_option('backtest_start_date', self.start_date.date())
         
         # 发布回测开始事件
         await self.event_bus.emit(BacktestStartEvent(
@@ -224,6 +227,7 @@ class AsyncBacktestEngine(BacktestEngine):
 
         # load_strategy 内部会重置设置，这里重新注入频率
         set_option('backtest_frequency', self.frequency)
+        set_option('backtest_start_date', self.start_date.date())
         
         # 初始化上下文（同步）
         self._initialize_context()

--- a/bullet_trade/core/async_scheduler.py
+++ b/bullet_trade/core/async_scheduler.py
@@ -16,6 +16,7 @@ import inspect
 import traceback
 
 from .scheduler import TimeExpression, get_market_periods, get_time_aliases
+from .settings import get_settings
 from .globals import log
 
 
@@ -66,6 +67,7 @@ class AsyncScheduleTask:
     expression: Optional[TimeExpression] = None
     weekday: Optional[int] = None
     monthday: Optional[int] = None
+    force: bool = False
     overlap_strategy: OverlapStrategy = OverlapStrategy.SKIP
     enabled: bool = True
     task_id: str = field(default_factory=lambda: '')
@@ -115,8 +117,8 @@ class AsyncScheduleTask:
         if expr.kind == 'every_bar':
             return is_bar
         
-        if self.schedule_type == ScheduleType.WEEKLY and self.weekday is not None:
-            if current_dt.weekday() != self.weekday:
+        if self.schedule_type == ScheduleType.WEEKLY:
+            if not self._should_trigger_weekly(current_dt.date(), previous_trade_day):
                 return False
 
         if self.schedule_type == ScheduleType.MONTHLY:
@@ -161,6 +163,44 @@ class AsyncScheduleTask:
         monthday = self.monthday
         if monthday < 1 or monthday > 31:
             return False
+
+        # force 语义（与同步 scheduler 一致）：若回测 start_day 晚于 monthday，默认认为本月已错过。
+        # force=True 时，在回测启动当月的最早可用交易日补跑一次。
+        try:
+            start_val = get_settings().options.get('backtest_start_date')
+        except Exception:
+            start_val = None
+
+        backtest_start_date: Optional[date] = None
+        if isinstance(start_val, datetime):
+            backtest_start_date = start_val.date()
+        elif isinstance(start_val, date):
+            backtest_start_date = start_val
+        elif isinstance(start_val, str):
+            s = start_val.strip()
+            if s:
+                for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+                    try:
+                        backtest_start_date = datetime.strptime(s, fmt).date()
+                        break
+                    except ValueError:
+                        continue
+
+        if backtest_start_date is not None:
+            if (backtest_start_date.year, backtest_start_date.month) == (current_date.year, current_date.month):
+                if backtest_start_date.day > monthday:
+                    if not bool(getattr(self, 'force', False)):
+                        return False
+                    if current_date < backtest_start_date:
+                        return False
+                    if previous_trade_day is not None and previous_trade_day >= backtest_start_date:
+                        return False
+                    marker = (current_date.year, current_date.month)
+                    if self.last_trigger_marker == marker:
+                        return False
+                    self.last_trigger_marker = marker
+                    return True
+
         if current_date.day < monthday:
             return False
         marker = (current_date.year, current_date.month)
@@ -170,6 +210,57 @@ class AsyncScheduleTask:
             return False
         self.last_trigger_marker = marker
         return True
+
+    @staticmethod
+    def _week_marker(d: date) -> Tuple[int, int]:
+        iso = d.isocalendar()
+        return int(iso.year), int(iso.week)
+
+    def _should_trigger_weekly(self, current_date: date, previous_trade_day: Optional[date]) -> bool:
+        if self.weekday is None:
+            return False
+        target_weekday = int(self.weekday)
+        if target_weekday < 0 or target_weekday > 6:
+            return False
+
+        # force 语义：若回测 start_day 的 weekday 晚于指定 weekday，默认视为本周已错过。
+        # force=True 时，在回测启动当周的最早可用交易日补跑一次。
+        try:
+            start_val = get_settings().options.get('backtest_start_date')
+        except Exception:
+            start_val = None
+
+        backtest_start_date: Optional[date] = None
+        if isinstance(start_val, datetime):
+            backtest_start_date = start_val.date()
+        elif isinstance(start_val, date):
+            backtest_start_date = start_val
+        elif isinstance(start_val, str):
+            s = start_val.strip()
+            if s:
+                for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+                    try:
+                        backtest_start_date = datetime.strptime(s, fmt).date()
+                        break
+                    except ValueError:
+                        continue
+
+        if backtest_start_date is not None:
+            if self._week_marker(backtest_start_date) == self._week_marker(current_date):
+                if backtest_start_date.weekday() > target_weekday:
+                    if not bool(getattr(self, 'force', False)):
+                        return False
+                    if current_date < backtest_start_date:
+                        return False
+                    if previous_trade_day is not None and previous_trade_day >= backtest_start_date:
+                        return False
+                    marker = self._week_marker(current_date)
+                    if self.last_trigger_marker == marker:
+                        return False
+                    self.last_trigger_marker = marker
+                    return True
+
+        return current_date.weekday() == target_weekday
     
     async def execute(self, *args, **kwargs) -> Any:
         """
@@ -332,7 +423,8 @@ class AsyncScheduler:
         func: Callable,
         weekday: int,
         time: str = 'open',
-        overlap_strategy: OverlapStrategy = OverlapStrategy.SKIP
+        overlap_strategy: OverlapStrategy = OverlapStrategy.SKIP,
+        force: bool = False,
     ) -> str:
         """
         每周运行任务
@@ -356,6 +448,7 @@ class AsyncScheduler:
             time=time,
             expression=expression,
             weekday=weekday,
+            force=bool(force),
             overlap_strategy=overlap_strategy
         )
         
@@ -366,7 +459,8 @@ class AsyncScheduler:
         func: Callable,
         monthday: int,
         time: str = 'open',
-        overlap_strategy: OverlapStrategy = OverlapStrategy.SKIP
+        overlap_strategy: OverlapStrategy = OverlapStrategy.SKIP,
+        force: bool = False,
     ) -> str:
         """
         每月运行任务
@@ -390,6 +484,7 @@ class AsyncScheduler:
             time=time,
             expression=expression,
             monthday=monthday,
+            force=bool(force),
             overlap_strategy=overlap_strategy
         )
         

--- a/bullet_trade/core/engine.py
+++ b/bullet_trade/core/engine.py
@@ -418,12 +418,14 @@ class BacktestEngine:
         # 设置回测频率到 settings（供 scheduler 使用）
         from .settings import set_option
         set_option('backtest_frequency', self.frequency)
+        set_option('backtest_start_date', self.start_date.date())
         
         # 加载策略
         self.load_strategy()
 
         # 注意：load_strategy 内部会调用 reset_settings()，需要重新注入频率配置
         set_option('backtest_frequency', self.frequency)
+        set_option('backtest_start_date', self.start_date.date())
         
         # 初始化上下文
         self.context = Context(

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -11,6 +11,7 @@ from bullet_trade.core.scheduler import (
     run_weekly,
     unschedule_all,
 )
+from bullet_trade.core.settings import set_option
 
 
 @pytest.fixture(autouse=True)
@@ -80,6 +81,31 @@ def test_weekly_open_offset_only_on_target_weekday():
     assert dt.datetime(2024, 6, 11, 9, 0) not in schedule_tue
 
 
+def test_weekly_force_runs_on_backtest_start_week_when_start_after_weekday():
+    # 回测从周三开始，weekly 任务设为每周一。
+    # - force=False: 认为本周已错过，不补跑
+    # - force=True: 在回测启动当周的首个可用交易日（即回测首日）补跑一次
+    set_option('backtest_start_date', dt.date(2024, 6, 12))  # 周三
+
+    run_weekly(lambda ctx: None, weekday=0, time='10:00', force=False)  # 周一
+    schedule_no_force = _build_schedule(dt.datetime(2024, 6, 12), previous_day=None)
+    assert dt.datetime(2024, 6, 12, 10, 0) not in schedule_no_force
+
+    unschedule_all()
+    run_weekly(lambda ctx: None, weekday=0, time='10:00', force=True)
+    schedule_force = _build_schedule(dt.datetime(2024, 6, 12), previous_day=None)
+    assert dt.datetime(2024, 6, 12, 10, 0) in schedule_force
+
+
+def test_weekly_force_only_affects_start_week_next_week_normal():
+    set_option('backtest_start_date', dt.date(2024, 6, 12))  # 周三
+    run_weekly(lambda ctx: None, weekday=0, time='10:00', force=True)  # 周一
+
+    # 下周一（6/17）应按指定 weekday 正常触发
+    schedule_next_monday = _build_schedule(dt.datetime(2024, 6, 17), previous_day=dt.date(2024, 6, 14))
+    assert dt.datetime(2024, 6, 17, 10, 0) in schedule_next_monday
+
+
 def test_monthly_close_offset_rolls_forward_for_holiday():
     run_monthly(lambda ctx: None, monthday=15, time="close+1h")
     # 2024-06-17 是周一，15日为周六，应该顺延到 17 日
@@ -88,3 +114,28 @@ def test_monthly_close_offset_rolls_forward_for_holiday():
     schedule = _build_schedule(trade_day, previous_trade_day)
     expected = dt.datetime(2024, 6, 17, 16, 0)
     assert expected in schedule
+
+
+def test_monthly_force_runs_on_backtest_start_month_when_start_after_monthday():
+    # 回测从 6/20 开始，月度任务设为每月 1 号。
+    # - force=False: 认为当月已错过，不应在 6 月补跑
+    # - force=True: 应在 6 月内最近的交易日（即回测首日）补跑一次
+    set_option('backtest_start_date', dt.date(2024, 6, 20))
+
+    run_monthly(lambda ctx: None, monthday=1, time='10:00', force=False)
+    schedule_no_force = _build_schedule(dt.datetime(2024, 6, 20), previous_day=None)
+    assert dt.datetime(2024, 6, 20, 10, 0) not in schedule_no_force
+
+    unschedule_all()
+    run_monthly(lambda ctx: None, monthday=1, time='10:00', force=True)
+    schedule_force = _build_schedule(dt.datetime(2024, 6, 20), previous_day=None)
+    assert dt.datetime(2024, 6, 20, 10, 0) in schedule_force
+
+
+def test_monthly_force_only_affects_start_month_next_month_normal():
+    set_option('backtest_start_date', dt.date(2024, 6, 20))
+    run_monthly(lambda ctx: None, monthday=1, time='10:00', force=True)
+
+    # 进入 7 月后，按 monthday=1 正常运行（这里 7/1 是周一）
+    schedule_july = _build_schedule(dt.datetime(2024, 7, 1), previous_day=dt.date(2024, 6, 28))
+    assert dt.datetime(2024, 7, 1, 10, 0) in schedule_july


### PR DESCRIPTION
同步聚宽功能：
- 回测的start_day对应的weekday要是晚于指定的weekday，在force=True时，这个weekly任务会在周内寻找最近的一个可用交易日执行。在下个周开始，schedule按指定的weekday正常运行
- 回测的start_day要是晚于指定的monthday，在force=True时，这个monthly任务会在月内寻找最近的一个可用交易日执行。在下个月开始，schedule按指定的monthday正常运行