### PR TITLE
Fix avg_cost and last_price for 国金 miniqmt

### DIFF
--- a/bullet_trade/broker/qmt.py
+++ b/bullet_trade/broker/qmt.py
@@ -806,9 +806,12 @@ class QmtBroker(BrokerBase):
         except Exception:
             raw_positions = None
         positions: List[Dict[str, Any]] = []
-        codes = [p.stock_code for p in raw_positions]
-        from xtquant import xtdata  # type: ignore
-        ticks = xtdata.get_full_tick(codes) if codes else {}
+        try:
+            from xtquant import xtdata  # type: ignore
+            codes = [p.stock_code for p in raw_positions]
+            ticks = xtdata.get_full_tick(codes) if codes else {}
+        except Exception:
+            ticks = {}
         if raw_positions:
             for pos in raw_positions:
                 try:
@@ -843,7 +846,7 @@ class QmtBroker(BrokerBase):
                         or getattr(pos, "current_price", None)
                         or getattr(pos, "last", None)
                     )
-                    if not last and pos.stock_code in ticks and ticks[pos.stock_code]:
+                    if ticks and not last and pos.stock_code in ticks and ticks[pos.stock_code]:
                         last = ticks[pos.stock_code].get("lastPrice")
                     market_value = getattr(pos, "market_value", None)
                     if market_value is None and last is not None:


### PR DESCRIPTION
可能是需要兼容xtquant的旧版本字段
修复前：
<img width="1724" height="178" alt="78569872b4fa3f12aa61e9cfbf883377" src="https://github.com/user-attachments/assets/5a2e51a4-c5d4-4e6e-96a2-09a1ea1350a9" />
修复后：
<img width="679" height="116" alt="image" src="https://github.com/user-attachments/assets/a3bca152-82e8-43a6-853b-a3e4411fd6e7" />
