### PR TITLE
Fix qmt broker security name missing

### DIFF
--- a/bullet_trade/broker/qmt.py
+++ b/bullet_trade/broker/qmt.py
@@ -854,9 +854,15 @@ class QmtBroker(BrokerBase):
                             market_value = float(last) * float(qty or 0)
                         except Exception:
                             market_value = None
+                    try:
+                        from xtquant import xtdata  # type: ignore
+                        name = xtdata.get_instrument_detail(code).get("InstrumentName")
+                    except Exception:
+                        name = None
                     positions.append(
                         {
                             "security": self._map_to_jq_symbol(code),
+                            "name": name,
                             "amount": int(qty or 0),
                             "closeable_amount": int(avail or 0),
                             "avg_cost": float(avg_cost or 0.0),


### PR DESCRIPTION
Prev：
<img width="661" height="346" alt="image" src="https://github.com/user-attachments/assets/8f75558f-5a9e-4daa-a58c-c40a117348dc" />

Fixed：
<img width="687" height="348" alt="image" src="https://github.com/user-attachments/assets/b14567fc-bde8-4330-81d2-3c306fe3d181" />
