### PR TITLE
增加tushare接口数据duckdb持久化及查询

### DIFF
--- a/bullet_trade/data/providers/tushare.py
+++ b/bullet_trade/data/providers/tushare.py
@@ -31,6 +31,8 @@ class TushareProvider(DataProvider):
         self._pro = None
         self._asset_type_cache: Dict[str, str] = {}
 
+        self._tushare_duckdb_path = self.config.get("tushare_duckdb_path",None) 
+
     # ------------------------ 公共工具 ------------------------
     @classmethod
     def _to_ts_code(cls, security: str) -> str:
@@ -52,8 +54,17 @@ class TushareProvider(DataProvider):
             return f"{code}.{mapped}"
         return security
 
-    @staticmethod
-    def _ensure_ts_module():
+    def _ensure_ts_module(self):
+        """返回 tushare 模块；配置了 tushare_duckdb_path 时返回本地优先的 tushare_duckdb。"""
+        if self._tushare_duckdb_path is not None:
+            try:
+                from . import tushare_duckdb as ts
+            except ImportError as exc:  # pragma: no cover - 仅在缺失依赖时触发
+                raise ImportError(
+                    "未安装 tushare_duckdb 依赖(duckdb)，无法使用本地 DuckDB，请执行 `pip install duckdb`"
+                ) from exc
+            ts.set_db_path(self._tushare_duckdb_path)
+            return ts
         try:
             import tushare as ts  # type: ignore
 
@@ -196,6 +207,8 @@ class TushareProvider(DataProvider):
         ts = self._ensure_ts_module()
         self._pro = ts.pro_api(token)
         self._token = token
+        # tushare_duckdb 回退远程时内部会调用无参的 pro_api()，需要全局 token
+        ts.set_token(token)
         # 支持自定义 API URL
         tushare_custom_url = host or self._tushare_custom_url
         if tushare_custom_url:
@@ -286,7 +299,6 @@ class TushareProvider(DataProvider):
         pro = self._ensure_client()
         asset = asset or self._infer_asset(security)
         ts_code = self._to_ts_code(security)
-
         df = ts.pro_bar(
             ts_code=ts_code,
             start_date=start_str,

--- a/bullet_trade/data/providers/tushare_duckdb.py
+++ b/bullet_trade/data/providers/tushare_duckdb.py
@@ -1,0 +1,315 @@
+"""
+tushare_duckdb — tushare 模块的「本地优先」封装。
+
+用法
+----
+    import tushare_duckdb as ts
+
+    ts.set_token("你的token")            # 同 tushare 用法
+    df = ts.daily(ts_code="000001.SZ",
+                  start_date="20260701", end_date="20260731")
+    df2 = ts.fund_daily(ts_code="159865.SZ", ...)
+    df3 = ts.adj_factor(ts_code="000001.SZ", ...)
+    df4 = ts.fund_adj(ts_code="159865.SZ", ...)
+    df5 = ts.pro_bar(ts_code="000001.SZ", asset="E", ...)
+
+设计目标
+--------
+1. 以下方法被重写，规则一致：先查本地 DuckDB → 有数据直接返回 → 否则回退父逻辑：
+   - `daily`      → 本地 `stk_daily`
+   - `fund_daily` → 本地 `etf_daily`
+   - `adj_factor` → 本地 `stk_adj_factor`
+   - `fund_adj`   → 本地 `fund_adj_factor`
+2. `pro_bar` 被重写：当 `adj=None、freq='D'、asset∈{FD,E}` 且无均线等短路条件
+   满足时，走本地 daily / fund_daily；否则回退父函数 `ts.pro_bar(...)`。
+3. 其它所有方法 / 属性通过模块 `__getattr__` 委托给 `tushare` 模块，
+   行为与直接 `import tushare` 完全一致。
+
+注意
+----
+- tushare 模块本身没有模块级 `daily` / `fund_daily` / `adj_factor` / `fund_adj`，
+  父逻辑即 `ts.pro_api().<方法>(...)`；`pro_bar` 是 tushare 模块级函数，回退时
+  传 `api=ts.pro_api()` 复用父逻辑。
+- 本地表 `trade_date` 为 DATE 类型，返回时转回 tushare 的 `YYYYMMDD` 字符串，
+  保证与远程结果一致；`fund_daily` 的列序中 pre_close 在 open 之前，与 daily 不同。
+- 默认库路径 `./duckdb/tushare.duckdb`，可用 `set_db_path()` 覆盖。
+"""
+
+import os
+
+import duckdb
+import pandas as pd
+
+import tushare as _ts
+
+
+# ---------------------------------------------------------------------- #
+# 模块配置
+# ---------------------------------------------------------------------- #
+_STK_DAILY_TABLE = "stk_daily"
+_ETF_DAILY_TABLE = "etf_daily"
+_STK_ADJ_FACTOR_TABLE = "stk_adj_factor"
+_FUND_ADJ_FACTOR_TABLE = "fund_adj_factor"
+_DEFAULT_DB_PATH = "./duckdb/tushare.duckdb"
+
+#: 本地 stk_daily 的标准列（顺序与 tushare daily 默认返回一致）
+_DAILY_COLUMNS = [
+    "ts_code", "trade_date", "open", "high", "low", "close",
+    "pre_close", "change", "pct_chg", "vol", "amount",
+]
+
+#: 本地 etf_daily 的标准列（顺序与 tushare fund_daily 默认返回一致，
+#: 注意 fund_daily 的 pre_close 在 open 之前，与 daily 不同）
+_FUND_DAILY_COLUMNS = [
+    "ts_code", "trade_date", "pre_close", "open", "high", "low",
+    "close", "change", "pct_chg", "vol", "amount",
+]
+
+#: 复权因子表的标准列（stk_adj_factor / fund_adj_factor 一致，
+#: 顺序与 tushare adj_factor / fund_adj 默认返回一致）
+_ADJ_FACTOR_COLUMNS = [
+    "ts_code", "trade_date", "adj_factor",
+]
+
+_db_path = _DEFAULT_DB_PATH
+
+
+def set_db_path(path):
+    """设置本地 DuckDB 文件路径（默认 ./duckdb/tushare.duckdb）。"""
+    global _db_path
+    _db_path = path
+
+
+# ---------------------------------------------------------------------- #
+# 重写 daily / fund_daily / adj_factor / fund_adj
+# ---------------------------------------------------------------------- #
+def daily(fields='', **kwargs):
+    """
+    重写 tushare daily：
+
+    1. 先用调用参数查询本地 `stk_daily` 表；
+    2. 有数据 → 返回本地结果（列格式与远程一致）；
+    3. 无数据（或本地库/表不可用）→ 回退 tushare 父逻辑 pro.daily。
+    """
+    return _local_common("daily", _STK_DAILY_TABLE, _DAILY_COLUMNS, fields, kwargs)
+
+
+def fund_daily(fields='', **kwargs):
+    """
+    重写 tushare fund_daily：查本地 `etf_daily`，未命中回退 pro.fund_daily。
+    """
+    return _local_common(
+        "fund_daily", _ETF_DAILY_TABLE, _FUND_DAILY_COLUMNS, fields, kwargs
+    )
+
+
+def adj_factor(fields='', **kwargs):
+    """
+    重写 tushare adj_factor：查本地 `stk_adj_factor`，未命中回退 pro.adj_factor。
+    """
+    return _local_common(
+        "adj_factor", _STK_ADJ_FACTOR_TABLE, _ADJ_FACTOR_COLUMNS, fields, kwargs
+    )
+
+
+def fund_adj(fields='', **kwargs):
+    """
+    重写 tushare fund_adj：查本地 `fund_adj_factor`，未命中回退 pro.fund_adj。
+    """
+    return _local_common(
+        "fund_adj", _FUND_ADJ_FACTOR_TABLE, _ADJ_FACTOR_COLUMNS, fields, kwargs
+    )
+
+
+def _local_common(api_name, table, columns, fields, kwargs):
+    """
+    daily / fund_daily / adj_factor / fund_adj 的公共重写逻辑：
+    先查本地表，命中返回；未命中回退 tushare 父逻辑。
+    """
+    df = _query_local(table, columns, fields, kwargs)
+    if df is not None and not df.empty:
+        return df
+
+    # 回退父逻辑：tushare 的 pro_api().{api_name}(...)
+    return getattr(_ts.pro_api(), api_name)(fields=fields, **kwargs)
+
+
+# ---------------------------------------------------------------------- #
+# 重写 pro_bar
+# ---------------------------------------------------------------------- #
+def pro_bar(ts_code='', start_date='', end_date='', freq='D', asset='E',
+            exchange='', adj=None, ma=[], factors=None, adjfactor=False,
+            offset=None, limit=None, fields='', contract_type='', retry_count=3,
+            api=None):
+    """
+    重写 tushare pro_bar：
+
+    短路条件（全部满足时优先走本地）：
+        adj=None、freq='D'、asset∈{FD,E}、无均线（ma 为 None 或空列表）、
+        adjfactor∈{None,False}，且 fields/factors/offset/limit 均为默认值。
+        （ma=[] 等价于 ma=None —— tushare 的默认无均线值）
+    - asset='FD' → 调 fund_daily（查本地 etf_daily）
+    - asset='E'  → 调 daily（查本地 stk_daily）
+    命中非空 → 直接返回本地结果；
+    否则 → 回退父函数 ts.pro_bar(..., api=api or ts.pro_api())。
+    """
+    # 归一化 freq / asset（与 tushare pro_bar 内部逻辑一致）
+    freq_s = freq.strip()
+    freq_norm = (
+        freq_s.lower()
+        if len(freq_s) >= 3
+        else (freq_s.upper() if asset.strip().upper() != 'C' else freq_s.lower())
+    )
+    asset_norm = asset.strip().upper()
+
+    no_ma = ma is None or (isinstance(ma, (list, tuple)) and len(ma) == 0)
+
+    can_shortcut = (
+        adj is None
+        and freq_norm == 'D'
+        and asset_norm in ('FD', 'E')
+        and no_ma
+        and adjfactor in (None, False)
+        and (fields in ('', None))
+        and (factors is None or len(factors) == 0)
+        and offset is None
+        and limit is None
+    )
+    if can_shortcut:
+        kwargs = dict(ts_code=ts_code, start_date=start_date, end_date=end_date)
+        if asset_norm == 'FD':
+            data = fund_daily(**kwargs)
+        if asset_norm == 'E':  # 'E'
+            data = daily(**kwargs)
+        if data is not None and not data.empty:
+            return data
+
+    # 回退父函数 ts.pro_bar（api 未传入时用 ts.pro_api()）
+    return _ts.pro_bar(
+        ts_code=ts_code, api=api or _ts.pro_api(), start_date=start_date, end_date=end_date,
+        freq=freq, asset=asset, exchange=exchange, adj=adj, ma=ma,
+        factors=factors, adjfactor=adjfactor, offset=offset, limit=limit,
+        fields=fields, contract_type=contract_type, retry_count=retry_count,
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 本地查询实现
+# ---------------------------------------------------------------------- #
+def _query_local(table, columns, fields='', kwargs=None):
+    """构造 WHERE 条件查询本地表（stk_daily / etf_daily / 复权因子表）。"""
+    kwargs = kwargs or {}
+    ts_code = kwargs.get("ts_code")
+    trade_date = kwargs.get("trade_date")
+    start_date = kwargs.get("start_date")
+    end_date = kwargs.get("end_date")
+
+    # 没有任何筛选条件：不查本地（避免全表扫描），直接回退远程
+    if not any([ts_code, trade_date, start_date, end_date]):
+        return None
+
+    # 库文件不存在：回退远程
+    if not os.path.exists(_db_path):
+        return None
+
+    conds, params = [], []
+    if ts_code:
+        conds.append("ts_code = ?")
+        params.append(str(ts_code))
+    if trade_date:
+        conds.append("trade_date = ?")
+        params.append(_to_date(trade_date))
+    if start_date:
+        conds.append("trade_date >= ?")
+        params.append(_to_date(start_date))
+    if end_date:
+        conds.append("trade_date <= ?")
+        params.append(_to_date(end_date))
+
+    select_cols = _resolve_select_columns(fields, columns)
+    sql = (
+        f"SELECT {', '.join(select_cols)} "
+        f"FROM {table} "
+        f"WHERE {' AND '.join(conds)}"
+    )
+    try:
+        con = duckdb.connect(_db_path, read_only=True)
+        try:
+            df = con.execute(sql, params).fetchdf()
+        finally:
+            con.close()
+    except Exception:
+        # 表不存在 / 查询异常：回退远程
+        return None
+
+    # trade_date 从 DATE 转回 tushare 的 YYYYMMDD 字符串
+    if len(df) and "trade_date" in df.columns:
+        df["trade_date"] = df["trade_date"].dt.strftime("%Y%m%d")
+    return df
+
+
+# ---------------------------------------------------------------------- #
+# 工具函数
+# ---------------------------------------------------------------------- #
+def _to_date(s):
+    """把 tushare 的 YYYYMMDD 字符串转成 DuckDB DATE 字面量格式。"""
+    if isinstance(s, str):
+        s = s.strip()
+        if len(s) == 8 and s.isdigit():
+            return f"{s[:4]}-{s[4:6]}-{s[6:]}"
+        return s
+    return s
+
+
+def _resolve_select_columns(fields, columns):
+    """解析 fields 参数为合法的本地列列表（过滤不存在的列）。"""
+    if fields:
+        cols = [c.strip() for c in str(fields).split(",") if c.strip()]
+        cols = [c for c in cols if c in columns]
+        if cols:
+            return cols
+    return columns
+
+
+# ---------------------------------------------------------------------- #
+# 模块级继承：其它一切委托给 tushare 模块（PEP 562）
+# ---------------------------------------------------------------------- #
+def __getattr__(name):
+    """模块级 __getattr__：本模块未定义的属性/方法全部委托给 tushare。"""
+    return getattr(_ts, name)
+
+
+def __dir__():
+    """dir() 同时展示本模块与 tushare 模块的符号。"""
+    return sorted(set(globals().keys()) | set(dir(_ts)))
+
+
+if __name__ == "__main__":
+    # 1) daily 本地命中（stk_daily 覆盖至今）
+    df1 = daily(ts_code="000001.SZ", start_date="20260720", end_date="20260731")
+    print("daily 本地命中 df1 shape:", df1.shape, "cols:", list(df1.columns))
+    print(df1.head())
+
+    # 2) fund_daily 本地命中（etf_daily 已同步）
+    df2 = fund_daily(ts_code="159865.SZ", start_date="20260720", end_date="20260731")
+    print("fund_daily 本地命中 df2 shape:", df2.shape, "cols:", list(df2.columns))
+    print(df2.head())
+
+    # 3) adj_factor 本地命中（本地覆盖区间 2020-01-02 ~ 2022-02-07）
+    df3 = adj_factor(ts_code="000001.SZ", start_date="20220101", end_date="20220207")
+    print("adj_factor 本地命中 df3 shape:", df3.shape, "cols:", list(df3.columns))
+    print(df3.head())
+
+    # 4) fund_adj 本地为空 → 回退远程（真实 token）
+    df4 = fund_adj(ts_code="159865.SZ", start_date="20220101", end_date="20220207")
+    print("fund_adj 回退 df4 shape:", df4.shape, "cols:", list(df4.columns))
+    print(df4.head())
+
+    # 5) pro_bar 短路：asset='E' 走本地 daily
+    df5 = pro_bar(ts_code="000001.SZ", asset="E",
+                  start_date="20260720", end_date="20260731")
+    print("pro_bar 短路 df5 shape:", df5.shape, "cols:", list(df5.columns))
+    print(df5.head())
+
+    # 委托验证：set_token 等由 tushare 模块提供
+    print("set_token 委托自 tushare:", getattr(_ts, "set_token"))

--- a/bullet_trade/utils/env_loader.py
+++ b/bullet_trade/utils/env_loader.py
@@ -173,6 +173,8 @@ def get_data_provider_config() -> dict:
             "token": get_env("TUSHARE_TOKEN"),
             "cache_dir": cache_dir_for("tushare"),
             "tushare_custom_url": get_env("TUSHARE_CUSTOM_URL"),
+            #tushare_duckdb_path 用于 tushare_duckdb模块数据源，若未设置则使用默认tushare模块
+            "tushare_duckdb_path": get_env("tushare_duckdb_path"),
         },
         "qmt": {
             "data_dir": get_env("QMT_DATA_PATH"),

--- a/docs/data/DATA_PROVIDER_TUSHARE.md
+++ b/docs/data/DATA_PROVIDER_TUSHARE.md
@@ -31,4 +31,16 @@
 3. **资产类型判断**：常见股票/指数/ETF 代码会先通过后缀和前缀快速判断；无法确定时回退到 `index_basic` / `fund_basic` / `stock_basic` 目录查询。
 4. **分钟线权限**：若账号未开通分钟级别数据，`ts.pro_bar` 会返回空 DataFrame；框架会在日志层面记录，策略需自行兜底。
 
+## duckdb持久化Tushare数据的查询功能开启
+- 配置.env参数**tushare_duckdb_path=/path**，开启本地tushare数据查询，开启前请先执行/helps/tushare_persistence/sync_table.py持久化数据前置任务。
+- 数据获取逻辑“bullet-trade”回测框架-->TushareProvider-->若tushare_duckdb成功查询数据返回 | 否则退回tushare原生接口。
+- 目前仅对股票、基金日线数据做持久化，其它证券数据可以参考代码进行拓展。
+>> 因tushare库原生接口仅支持单一证券代码查询，当查询证券代码列表日线价格，需要逐个代码查询tushare接口耗时长。如下
+>> ```bash
+>> get_price(all_stocks.index.tolist(), end_date=end_date, count=trade_days, fields=['close','money'], panel=False)
+>> ```
+>> duckdb持久化为改善以上性能问题而开发
+
+    
+
 总体而言，TushareProvider 在无需依赖聚宽账号的情况下提供了等价的 API 行为，并支持动态复权与标准化分红事件，是纯离线或学术环境的推荐选择。***

--- a/helpers/tushare_persistence/check_quality.py
+++ b/helpers/tushare_persistence/check_quality.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""DuckDB 数据质量检查脚本（自包含，无项目内部依赖）。
+
+对指定 DuckDB 表执行标准质检并输出结构化报告。
+
+依赖：pip install duckdb pandas loguru
+
+用法::
+
+    python check_quality.py \\
+        --duckdb-path ./ashare.duckdb \\
+        --table stk_daily \\
+        --pk ts_code,trade_date \\
+        --date-col trade_date
+
+    # 输出 JSON 格式
+    python check_quality.py \\
+        --duckdb-path ./ashare.duckdb \\
+        --table stk_info \\
+        --pk ts_code \\
+        --format json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import duckdb
+from loguru import logger
+
+
+def _fq(table: str) -> str:
+    parts = table.split(".")
+    if len(parts) == 2:
+        return f'"{parts[0]}"."{parts[1]}"'
+    return f'"{table}"'
+
+
+def _parse_schema_table(table: str):
+    """Return (schema, table_name) for information_schema queries."""
+    parts = table.split(".")
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return None, parts[0]
+
+
+def _col_info_where(schema, table_name):
+    """Return (WHERE clause, params) for information_schema.columns."""
+    if schema:
+        return "table_schema = ? AND table_name = ?", [schema, table_name]
+    return "table_schema = current_schema() AND table_name = ?", [table_name]
+
+
+def check_quality(
+    duckdb_path: str,
+    table: str,
+    pk_cols: List[str],
+    date_col: Optional[str] = None,
+) -> Dict:
+    """Run quality checks on a DuckDB table. Returns structured report dict."""
+    fq = _fq(table)
+    report = {
+        "table": table,
+        "check_time": datetime.now().isoformat(),
+        "checks": {},
+        "passed": True,
+    }
+
+    with duckdb.connect(duckdb_path, read_only=True) as con:
+        # 1. Row count
+        row_count = con.execute(f"SELECT COUNT(*) FROM {fq}").fetchone()[0]
+        report["checks"]["row_count"] = {"value": row_count, "pass": row_count > 0}
+
+        # 2. PK uniqueness
+        pk_expr = ", ".join(f'"{c}"' for c in pk_cols)
+        dup_rows = con.execute(
+            f"SELECT {pk_expr}, COUNT(*) AS cnt FROM {fq} GROUP BY {pk_expr} HAVING cnt > 1 LIMIT 5"
+        ).fetchall()
+        dup_count = len(dup_rows)
+        report["checks"]["pk_unique"] = {
+            "value": dup_count,
+            "pass": dup_count == 0,
+            "sample": [str(r) for r in dup_rows] if dup_rows else [],
+        }
+
+        # 3. PK null check (per column)
+        pk_nulls = {}
+        for col in pk_cols:
+            null_count = con.execute(f'SELECT COUNT(*) FROM {fq} WHERE "{col}" IS NULL').fetchone()[0]
+            pk_nulls[col] = null_count
+        all_pk_clean = all(v == 0 for v in pk_nulls.values())
+        report["checks"]["pk_no_null"] = {"value": pk_nulls, "pass": all_pk_clean}
+
+        # 4. Date range (if date_col provided)
+        if date_col:
+            date_range = con.execute(
+                f'SELECT MIN("{date_col}")::VARCHAR, MAX("{date_col}")::VARCHAR FROM {fq}'
+            ).fetchone()
+            report["checks"]["date_range"] = {
+                "min": date_range[0],
+                "max": date_range[1],
+                "pass": True,  # Informational - agent validates against latest trade date
+            }
+
+        # 5. Distinct ts_code count (if column exists)
+        schema, tbl = _parse_schema_table(table)
+        where, params = _col_info_where(schema, tbl)
+        cols_info = con.execute(
+            f"SELECT column_name FROM information_schema.columns "
+            f"WHERE {where} ORDER BY ordinal_position",
+            params,
+        ).fetchall()
+        col_names = [r[0] for r in cols_info]
+
+        if "ts_code" in col_names:
+            ts_count = con.execute(f'SELECT COUNT(DISTINCT "ts_code") FROM {fq}').fetchone()[0]
+            report["checks"]["distinct_ts_code"] = {"value": ts_count}
+
+        if date_col and date_col in col_names:
+            date_count = con.execute(f'SELECT COUNT(DISTINCT "{date_col}") FROM {fq}').fetchone()[0]
+            report["checks"]["distinct_dates"] = {"value": date_count}
+
+        # 6. NaN string pollution check
+        nan_cols = []
+        for col in col_names:
+            col_type = con.execute(
+                f"SELECT data_type FROM information_schema.columns "
+                f"WHERE {where} AND column_name = ?",
+                params + [col],
+            ).fetchone()
+            if col_type and col_type[0] == "VARCHAR":
+                cnt = con.execute(
+                    f"""SELECT COUNT(*) FROM {fq} WHERE "{col}" IN ('nan', 'NaN', 'NAN', 'None')"""
+                ).fetchone()[0]
+                if cnt > 0:
+                    nan_cols.append({"column": col, "count": cnt})
+        report["checks"]["nan_pollution"] = {
+            "value": nan_cols,
+            "pass": len(nan_cols) == 0,
+        }
+
+        # 7. Measure column null ratio (DOUBLE/FLOAT columns with > 50% null)
+        high_null_cols = []
+        if row_count > 0:
+            for col in col_names:
+                col_type = con.execute(
+                    f"SELECT data_type FROM information_schema.columns "
+                    f"WHERE {where} AND column_name = ?",
+                    params + [col],
+                ).fetchone()
+                if col_type and col_type[0] in ("DOUBLE", "FLOAT", "DECIMAL", "BIGINT", "INTEGER"):
+                    null_cnt = con.execute(
+                        f'SELECT COUNT(*) FROM {fq} WHERE "{col}" IS NULL'
+                    ).fetchone()[0]
+                    ratio = null_cnt / row_count
+                    if ratio > 0.5:
+                        high_null_cols.append({"column": col, "null_ratio": round(ratio, 4)})
+        report["checks"]["high_null_measures"] = {
+            "value": high_null_cols,
+            "pass": len(high_null_cols) == 0,
+        }
+
+    # Overall pass
+    for check in report["checks"].values():
+        if "pass" in check and not check["pass"]:
+            report["passed"] = False
+            break
+
+    return report
+
+
+def format_markdown(report: Dict) -> str:
+    """Format quality report as markdown table for embedding in metadata docs."""
+    checks = report["checks"]
+    t = report["check_time"]
+    lines = [
+        "| 指标 | 值 | 检查时间 |",
+        "|---|---|---|",
+        f"| 总行数 | {checks['row_count']['value']} | {t} |",
+    ]
+    if "date_range" in checks:
+        lines.append(f"| 数据起始 | {checks['date_range']['min']} | {t} |")
+        lines.append(f"| 数据截止 | {checks['date_range']['max']} | {t} |")
+    if "distinct_ts_code" in checks:
+        lines.append(f"| 股票数 (DISTINCT ts_code) | {checks['distinct_ts_code']['value']} | {t} |")
+    if "distinct_dates" in checks:
+        lines.append(f"| 交易日/报告期数 | {checks['distinct_dates']['value']} | {t} |")
+    lines.append(f"| PK 重复数 | {checks['pk_unique']['value']} | {t} |")
+    pk_null_str = ", ".join(f"{k}={v}" for k, v in checks["pk_no_null"]["value"].items())
+    lines.append(f"| PK 列 NULL 数 | {pk_null_str} | {t} |")
+    nan_val = checks["nan_pollution"]["value"]
+    nan_str = "无" if not nan_val else ", ".join(f"{x['column']}({x['count']})" for x in nan_val)
+    lines.append(f"| NaN 字符串污染列 | {nan_str} | {t} |")
+    high_null = checks["high_null_measures"]["value"]
+    hn_str = "无" if not high_null else ", ".join(f"{x['column']}({x['null_ratio']:.1%})" for x in high_null)
+    lines.append(f"| 度量列全 NULL 率 > 50% | {hn_str} | {t} |")
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser(description="DuckDB table quality check")
+    p.add_argument("--duckdb-path", required=True, help="Path to DuckDB file")
+    p.add_argument("--table", required=True, help="Table name to check")
+    p.add_argument("--pk", required=True, help="Comma-separated PK column names")
+    p.add_argument("--date-col", default=None, help="Date column name for range check")
+    p.add_argument("--format", default="text", choices=["text", "json", "markdown"])
+    args = p.parse_args()
+
+    pk_cols = [c.strip() for c in args.pk.split(",")]
+    report = check_quality(args.duckdb_path, args.table, pk_cols, args.date_col)
+
+    if args.format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2, default=str))
+    elif args.format == "markdown":
+        print(format_markdown(report))
+    else:
+        status = "✅ PASSED" if report["passed"] else "❌ FAILED"
+        print(f"\nQuality Report: {report['table']} — {status}")
+        print(f"Check Time: {report['check_time']}")
+        for name, check in report["checks"].items():
+            flag = "✓" if check.get("pass", True) else "✗"
+            print(f"  {flag} {name}: {check['value']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/tushare_persistence/readme.md
+++ b/helpers/tushare_persistence/readme.md
@@ -1,0 +1,20 @@
+# 此脚本实现tushare接口数据持久化到duckdb
+1. **tushare.initdb.sql** duckdb数据的初始化schema
+- 用 SQL 初始化一个全新数据库
+```bash
+duckdb ./duckdb/tushare.duckdb < tushare.initdb.sql
+```
+或 Python
+```bash
+python -c "import duckdb; duckdb.connect('x.duckdb').execute(open('tushare.initdb.sql').read())"
+```
+
+2. **sync_table.py**、**tasks_sync.json**配置需要同步的接口及执行同步操作，执行前需要设置环境变量“TUSHARE_TOKEN”
+```bash
+TUSHARE_TOKEN=your_token python sync_table.py --tasks-file tasks_sync.json --duckdb-path ./duckdb/tushare.duckdb
+```
+3. **check_quality.py** 用于检查持久化的数据质量
+4. **test_query_performance.py** 用于测试查询duckdb数据性能（日行情数据，1000次随机查询，约耗时3秒+）
+
+5. 核心同步代码使用tushare_duckdb_sync_skills生成
+https://github.com/shadowinlife/nano_quant_skills/tree/main/tushare_to_duckdb/tushare_duckdb_sync_skills

--- a/helpers/tushare_persistence/requirements.txt
+++ b/helpers/tushare_persistence/requirements.txt
@@ -1,0 +1,3 @@
+duckdb
+pandas
+loguru

--- a/helpers/tushare_persistence/sync_table.py
+++ b/helpers/tushare_persistence/sync_table.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""Tushare → DuckDB 单表同步脚本（自包含，无项目内部依赖）。
+
+支持三种维度：none（全量覆盖）、trade_date（按交易日增量）、period（按报告期增量）。
+同步状态记录在 DuckDB 内部的 table_sync_state 表中，支持断点续传。
+
+对 trade_date 维度，脚本默认采用 Asia/Shanghai 18:00 的安全截止规则：
+- 未显式传入 --end-date 时，18:00 前默认只同步到上一个开放交易日
+- 增量维度返回空 payload 时，默认记失败而不是成功，避免误标记
+- 只有显式传入 --allow-empty-result 时，才允许 0 行结果记成功
+
+依赖：pip install tushare duckdb pandas loguru
+
+用法示例::
+
+    # 全量覆盖（stock_basic 等无维度表）
+    TUSHARE_TOKEN=xxx python sync_table.py \\
+        --endpoint stock_basic \\
+        --duckdb-path ./ashare.duckdb \\
+        --target-table stk_info \\
+        --mode overwrite \\
+        --dimension-type none
+
+    # 增量同步（daily 等交易日维度表）
+    TUSHARE_TOKEN=xxx python sync_table.py \\
+        --endpoint daily \\
+        --duckdb-path ./ashare.duckdb \\
+        --target-table stk_daily \\
+        --mode append \\
+        --dimension-type trade_date \\
+        --start-date 20240101 \\
+        --sync-all
+
+    # 按任务文件批量同步
+    TUSHARE_TOKEN=xxx python sync_table.py \\
+        --tasks-file tasks.json \\
+        --duckdb-path ./ashare.duckdb
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import duckdb
+import pandas as pd
+from loguru import logger
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Python < 3.9 fallback
+    ZoneInfo = None
+
+# ---------------------------------------------------------------------------
+# Tushare client (cached singleton)
+# ---------------------------------------------------------------------------
+
+_tushare_client = None
+
+
+def _get_tushare_client():
+    global _tushare_client
+    if _tushare_client is None:
+        import tushare as ts
+
+        token = os.environ.get("TUSHARE_TOKEN")
+        if not token:
+            raise RuntimeError(
+                "TUSHARE_TOKEN environment variable is required. "
+                "Get your token at https://tushare.pro"
+            )
+        _tushare_client = ts.pro_api(token=token)
+    return _tushare_client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+DEFAULT_PUBLISH_CUTOFF_HOUR = 18
+
+
+class SyncError(Exception):
+    """Structured sync error with context dict."""
+
+    def __init__(self, message: str, context: Optional[Dict[str, object]] = None):
+        super().__init__(message)
+        self.context = context or {}
+
+
+def _log_event(event: str, payload: Dict[str, object]) -> None:
+    logger.info(json.dumps({"event": event, **payload}, ensure_ascii=False, default=str))
+
+
+def _parse_table_name(table_name: str) -> Tuple[Optional[str], str]:
+    parts = table_name.split(".")
+    if len(parts) == 1:
+        schema, table = None, parts[0]
+    elif len(parts) == 2:
+        schema, table = parts[0], parts[1]
+    else:
+        raise SyncError("Invalid table name. Use 'table' or 'schema.table'", {"table": table_name})
+    for piece in (schema, table):
+        if piece is not None and not VALID_IDENTIFIER.match(piece):
+            raise SyncError("Table identifier contains invalid characters", {"table": table_name})
+    return schema, table
+
+
+def _fq(schema: Optional[str], table: str) -> str:
+    return f'"{schema}"."{table}"' if schema else f'"{table}"'
+
+
+def _normalize_date(text: str) -> str:
+    for fmt in ("%Y%m%d", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt).strftime("%Y%m%d")
+        except ValueError:
+            continue
+    raise SyncError("Invalid date format. Use YYYYMMDD or YYYY-MM-DD", {"date": text})
+
+
+def _now_shanghai() -> datetime:
+    if ZoneInfo is None:
+        return datetime.now()
+    return datetime.now(ZoneInfo("Asia/Shanghai"))
+
+
+def _parse_params(params: Any) -> Dict[str, object]:
+    if params is None or params == "":
+        return {}
+    if isinstance(params, dict):
+        return dict(params)
+    if isinstance(params, str):
+        parsed = json.loads(params)
+        if not isinstance(parsed, dict):
+            raise SyncError("--params must be a JSON object", {"params": params})
+        return parsed
+    raise SyncError("--params must be a JSON object", {"params_type": type(params).__name__})
+
+
+def _allow_empty_result(args) -> bool:
+    return bool(getattr(args, "allow_empty_result", False))
+
+
+# ---------------------------------------------------------------------------
+# Sync state management
+# ---------------------------------------------------------------------------
+
+def _ensure_sync_state_table(con: duckdb.DuckDBPyConnection) -> str:
+    """Ensure table_sync_state exists and return its qualified name."""
+    # Check common candidates
+    for candidate in ("table_sync_state", "meta.table_sync_status"):
+        s, t = _parse_table_name(candidate)
+        check_sql = (
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema = ? AND table_name = ?"
+            if s
+            else "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema = current_schema() AND table_name = ?"
+        )
+        params = [s, t] if s else [t]
+        row = con.execute(check_sql, params).fetchone()
+        if row and int(row[0]) > 0:
+            return _fq(s, t)
+
+    # Create it
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS "table_sync_state" (
+            source_table VARCHAR,
+            dimension_type VARCHAR,
+            dimension_value VARCHAR,
+            is_sync INTEGER,
+            error_message VARCHAR,
+            updated_at TIMESTAMP
+        )
+        """
+    )
+    return '"table_sync_state"'
+
+
+def _write_sync_status(
+    con: duckdb.DuckDBPyConnection,
+    fq_state: str,
+    source_table: str,
+    dim_type: str,
+    dim_value: str,
+    is_sync: int,
+    error_msg: str = "",
+) -> None:
+    con.execute(
+        f"DELETE FROM {fq_state} WHERE source_table = ? AND dimension_type = ? AND dimension_value = ?",
+        [source_table, dim_type, dim_value],
+    )
+    con.execute(
+        f"INSERT INTO {fq_state} (source_table, dimension_type, dimension_value, is_sync, error_message, updated_at) "
+        f"VALUES (?, ?, ?, ?, ?, ?)",
+        [source_table, dim_type, dim_value, is_sync, error_msg, datetime.now()],
+    )
+
+
+def _list_synced(con: duckdb.DuckDBPyConnection, fq_state: str, source_table: str, dim_type: str) -> set:
+    rows = con.execute(
+        f"SELECT dimension_value FROM {fq_state} WHERE source_table = ? AND dimension_type = ? AND is_sync = 1",
+        [source_table, dim_type],
+    ).fetchall()
+    return {str(r[0]) for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Dimension resolution
+# ---------------------------------------------------------------------------
+
+def _get_trade_dates(client, start: str, end: str) -> List[str]:
+    cal = client.query("trade_cal", start_date=start, end_date=end)
+    if cal is None or cal.empty:
+        return []
+    return sorted(cal[cal["is_open"] == 1]["cal_date"].astype(str).tolist())
+
+
+def _get_report_periods(start: str, end: str) -> List[str]:
+    s = pd.to_datetime(start, format="%Y%m%d")
+    e = pd.to_datetime(end, format="%Y%m%d")
+    return sorted(pd.date_range(start=s, end=e, freq="QE-DEC").strftime("%Y%m%d").tolist())
+
+
+def _resolve_trade_date_end(client, args) -> str:
+    if args.end_date:
+        return _normalize_date(args.end_date)
+
+    now_sh = _now_shanghai()
+    today = now_sh.strftime("%Y%m%d")
+    if bool(getattr(args, "disable_safe_trade_date", False)):
+        return today
+
+    cutoff_hour = int(getattr(args, "publish_cutoff_hour", DEFAULT_PUBLISH_CUTOFF_HOUR))
+    if now_sh.hour >= cutoff_hour:
+        return today
+
+    lookback_start = (now_sh - timedelta(days=14)).strftime("%Y%m%d")
+    open_days = _get_trade_dates(client, lookback_start, today)
+    prior_open_days = [day for day in open_days if day < today]
+    if prior_open_days:
+        safe_end = prior_open_days[-1]
+        _log_event(
+            "safe_trade_date_applied",
+            {
+                "today": today,
+                "effective_end_date": safe_end,
+                "publish_cutoff_hour": cutoff_hour,
+                "timezone": "Asia/Shanghai",
+            },
+        )
+        return safe_end
+    return today
+
+
+def _resolve_dimensions(con, fq_state, client, source_table, args) -> List[str]:
+    if args.dimension_type == "none":
+        return [""]
+    start = _normalize_date(args.start_date or ("20100101" if args.dimension_type == "trade_date" else "20100331"))
+    if args.dimension_type == "trade_date":
+        end = _resolve_trade_date_end(client, args)
+        if start > end:
+            raise SyncError(
+                "No safe trade_date window is available yet. Retry after the publish cutoff or pass an explicit --end-date.",
+                {"start_date": start, "effective_end_date": end},
+            )
+        values = _get_trade_dates(client, start, end)
+    elif args.dimension_type == "period":
+        end = _normalize_date(args.end_date or datetime.now().strftime("%Y%m%d"))
+        values = _get_report_periods(start, end)
+    else:
+        raise SyncError("Unsupported dimension_type", {"dimension_type": args.dimension_type})
+    if not values:
+        return []
+    if args.sync_all:
+        synced = _list_synced(con, fq_state, source_table, args.dimension_type)
+        return [v for v in values if v not in synced]
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Tushare data fetch
+# ---------------------------------------------------------------------------
+
+def _fetch(client, args, dim_value: str) -> pd.DataFrame:
+    kwargs: Dict[str, object] = _parse_params(args.params)
+    if args.dimension_type != "none":
+        field = args.dimension_field or args.dimension_type
+        kwargs[field] = dim_value
+
+    last_exc = None
+    for attempt in range(1, args.max_retries + 1):
+        try:
+            method_name = args.method or "query"
+            if method_name == "query":
+                df = client.query(args.endpoint, **kwargs)
+            else:
+                if not hasattr(client, method_name):
+                    raise SyncError("Unsupported Tushare method", {"method": method_name})
+                df = getattr(client, method_name)(**kwargs)
+            if not isinstance(df, pd.DataFrame):
+                raise SyncError("Tushare did not return a DataFrame")
+            return df.copy()
+        except Exception as exc:
+            last_exc = exc
+            if attempt < args.max_retries:
+                wait = args.base_sleep * attempt
+                logger.warning(f"Fetch attempt {attempt}/{args.max_retries} failed: {exc}, retry in {wait:.1f}s")
+                time.sleep(wait)
+    raise SyncError(f"Fetch failed after {args.max_retries} retries: {last_exc}")
+
+
+def _ensure_expected_rows(df: pd.DataFrame, source: str, target: str, dim_value: str, args) -> None:
+    if args.dimension_type == "none" or _allow_empty_result(args) or not df.empty:
+        return
+
+    raise SyncError(
+        (
+            "Empty payload returned from Tushare for incremental sync; "
+            "not marking as successful. Retry after the publish cutoff or use --allow-empty-result if zero rows are expected."
+        ),
+        {
+            "source_table": source,
+            "target_table": target,
+            "dimension_type": args.dimension_type,
+            "dimension_value": dim_value,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# DuckDB write
+# ---------------------------------------------------------------------------
+
+def _table_exists(con, schema, table) -> bool:
+    if schema:
+        row = con.execute(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+            [schema, table],
+        ).fetchone()
+    else:
+        row = con.execute(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = ?",
+            [table],
+        ).fetchone()
+    return bool(row and int(row[0]) > 0)
+
+
+def _get_columns(con, schema, table) -> List[str]:
+    if schema:
+        rows = con.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position",
+            [schema, table],
+        ).fetchall()
+    else:
+        rows = con.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = ? ORDER BY ordinal_position",
+            [table],
+        ).fetchall()
+    return [str(r[0]) for r in rows]
+
+
+def _get_date_cols(con, schema, table) -> set:
+    if schema:
+        rows = con.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = ? AND table_name = ? AND data_type = 'DATE'",
+            [schema, table],
+        ).fetchall()
+    else:
+        rows = con.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = ? AND data_type = 'DATE'",
+            [table],
+        ).fetchall()
+    return {str(r[0]) for r in rows}
+
+
+def _coerce_dates(df: pd.DataFrame, date_cols: set) -> pd.DataFrame:
+    """Convert YYYYMMDD string columns to datetime64 for DuckDB DATE columns."""
+    for col in date_cols:
+        if col not in df.columns:
+            continue
+        s = df[col]
+        if s.dropna().empty:
+            continue
+        converted = pd.to_datetime(s, format="%Y%m%d", errors="coerce")
+        if converted.notna().sum() == 0:
+            converted = pd.to_datetime(s, errors="coerce")
+        df[col] = converted
+    return df
+
+
+def _write(con, df: pd.DataFrame, target: str, mode: str, first_batch: bool) -> Tuple[int, int]:
+    """Write DataFrame to DuckDB. Returns (total_rows, loaded_rows)."""
+    if df.empty:
+        s, t = _parse_table_name(target)
+        fq = _fq(s, t)
+        if not _table_exists(con, s, t):
+            return 0, 0
+        row = con.execute(f"SELECT COUNT(*) FROM {fq}").fetchone()
+        return (int(row[0]) if row else 0), 0
+
+    # Normalize NaN → None
+    normalized = df.where(pd.notna(df), None)
+    loaded = len(normalized)
+    s, t = _parse_table_name(target)
+    fq = _fq(s, t)
+    if s:
+        con.execute(f'CREATE SCHEMA IF NOT EXISTS "{s}"')
+    if mode == "overwrite" and first_batch:
+        con.execute(f"DROP TABLE IF EXISTS {fq}")
+
+    if not _table_exists(con, s, t):
+        con.register("_df", normalized)
+        con.execute(f"CREATE TABLE {fq} AS SELECT * FROM _df")
+        con.unregister("_df")
+    else:
+        cols = _get_columns(con, s, t)
+        extra = [c for c in normalized.columns if c not in cols]
+        if extra:
+            logger.warning(f"Dropping extra columns not in target: {extra}")
+        aligned = normalized.reindex(columns=cols)
+        dcols = _get_date_cols(con, s, t)
+        if dcols:
+            aligned = _coerce_dates(aligned.copy(), dcols)
+        con.register("_df", aligned)
+        con.execute(f"INSERT INTO {fq} SELECT * FROM _df")
+        con.unregister("_df")
+
+    row = con.execute(f"SELECT COUNT(*) FROM {fq}").fetchone()
+    total = int(row[0]) if row else loaded
+    return total, loaded
+
+
+# ---------------------------------------------------------------------------
+# Main sync logic
+# ---------------------------------------------------------------------------
+
+def sync_one_table(args) -> Dict[str, object]:
+    """Sync a single Tushare endpoint to DuckDB. Returns result summary dict."""
+    source = args.source_table or args.endpoint
+    target = args.target_table or source
+    db_path = Path(args.duckdb_path).expanduser().resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    client = _get_tushare_client()
+    with duckdb.connect(str(db_path)) as con:
+        fq_state = _ensure_sync_state_table(con)
+        dims = _resolve_dimensions(con, fq_state, client, source, args)
+
+        if not dims:
+            result = {
+                "source_table": source, "target_table": target,
+                "dimension_type": args.dimension_type,
+                "processed": 0, "loaded_rows": 0, "total_rows": 0,
+            }
+            _log_event("sync_skipped", result)
+            return result
+
+        _log_event("sync_started", {
+            "source_table": source, "target_table": target,
+            "dimension_type": args.dimension_type,
+            "dimensions": len(dims), "mode": args.mode,
+        })
+
+        processed = 0
+        total_loaded = 0
+        total_rows = 0
+        first_batch = True
+
+        for dim in dims:
+            try:
+                df = _fetch(client, args, dim)
+                _ensure_expected_rows(df, source, target, dim, args)
+                total_rows, loaded = _write(con, df, target, args.mode, first_batch)
+                first_batch = False
+                processed += 1
+                total_loaded += loaded
+
+                if args.dimension_type != "none":
+                    _write_sync_status(con, fq_state, source, args.dimension_type, dim, 1)
+
+                _log_event("dimension_done", {
+                    "source_table": source, "dimension": dim,
+                    "loaded": loaded, "total": total_rows,
+                })
+
+                if args.sleep > 0:
+                    time.sleep(args.sleep)
+
+            except Exception as exc:
+                if args.dimension_type != "none":
+                    _write_sync_status(con, fq_state, source, args.dimension_type, dim, 0, str(exc))
+                logger.error(f"Failed: source={source} dim={dim}: {exc}")
+                if args.sync_all:
+                    continue
+                raise
+
+    result = {
+        "source_table": source, "target_table": target,
+        "dimension_type": args.dimension_type, "mode": args.mode,
+        "processed": processed, "loaded_rows": total_loaded, "total_rows": total_rows,
+    }
+    _log_event("sync_completed", result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Tushare → DuckDB single-table sync",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument("--endpoint", help="Tushare endpoint name (e.g. stock_basic, daily)")
+    p.add_argument("--method", default="query", help="Tushare client method (default: query)")
+    p.add_argument("--source-table", default=None, help="Logical name for sync state tracking")
+    p.add_argument("--duckdb-path", required=True, help="Path to DuckDB file")
+    p.add_argument("--target-table", default=None, help="DuckDB target table name")
+    p.add_argument("--mode", default="overwrite", choices=["overwrite", "append"])
+    p.add_argument("--dimension-type", default="none", choices=["none", "trade_date", "period"])
+    p.add_argument("--dimension-field", default=None, help="Override dimension param name in API call")
+    p.add_argument("--start-date", default=None, help="Start date YYYYMMDD")
+    p.add_argument("--end-date", default=None, help="End date YYYYMMDD")
+    p.add_argument("--sync-all", action="store_true", help="Skip synced dims, continue on error")
+    p.add_argument("--params", default=None, help="Extra Tushare kwargs as JSON string")
+    p.add_argument("--max-retries", type=int, default=3, help="Max fetch retries (default: 3)")
+    p.add_argument("--base-sleep", type=float, default=2.0, help="Retry backoff base seconds")
+    p.add_argument("--sleep", type=float, default=0.3, help="Sleep between successful calls")
+    p.add_argument(
+        "--allow-empty-result",
+        action="store_true",
+        help="Treat empty payload as success. Use only when zero rows are semantically valid.",
+    )
+    p.add_argument(
+        "--disable-safe-trade-date",
+        action="store_true",
+        help="Disable the default Asia/Shanghai publish-cutoff guard for trade_date sync when --end-date is omitted.",
+    )
+    p.add_argument(
+        "--publish-cutoff-hour",
+        type=int,
+        default=DEFAULT_PUBLISH_CUTOFF_HOUR,
+        help="Asia/Shanghai hour after which today's trade_date is treated as safe when --end-date is omitted.",
+    )
+    p.add_argument("--tasks-file", default=None, help="JSON file with array of task objects (batch mode)")
+    return p
+
+
+def _merge_task(base_args, task: dict):
+    """Create a new namespace by overlaying task dict onto base args."""
+    import copy
+    merged = copy.deepcopy(base_args)
+    field_map = {
+        "endpoint": "endpoint", "method": "method",
+        "source_table": "source_table", "target_table": "target_table",
+        "mode": "mode", "dimension_type": "dimension_type",
+        "dimension_field": "dimension_field",
+        "start_date": "start_date", "end_date": "end_date",
+        "sync_all": "sync_all", "params": "params", "extra_params": "params",
+        "max_retries": "max_retries", "base_sleep": "base_sleep",
+        "sleep": "sleep", "sleep_seconds": "sleep",
+        "allow_empty_result": "allow_empty_result",
+        "disable_safe_trade_date": "disable_safe_trade_date",
+        "publish_cutoff_hour": "publish_cutoff_hour",
+    }
+    for json_key, attr in field_map.items():
+        if json_key in task:
+            setattr(merged, attr, task[json_key])
+    return merged
+
+
+def main():
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if args.tasks_file:
+        tasks_path = Path(args.tasks_file)
+        if not tasks_path.exists():
+            raise FileNotFoundError(f"Tasks file not found: {tasks_path}")
+        with open(tasks_path) as f:
+            tasks = json.load(f)
+        ok, fail = 0, 0
+        for i, task in enumerate(tasks):
+            task_args = _merge_task(args, task)
+            name = task.get("endpoint", f"task_{i}")
+            try:
+                result = sync_one_table(task_args)
+                logger.info(f"✅ {name}: loaded {result['loaded_rows']} rows, total {result['total_rows']}")
+                ok += 1
+            except Exception as exc:
+                logger.error(f"❌ {name}: {exc}")
+                fail += 1
+        logger.info(f"Batch done: {ok} succeeded, {fail} failed out of {len(tasks)} tasks")
+    else:
+        if not args.endpoint:
+            parser.error("--endpoint is required (unless using --tasks-file)")
+        sync_one_table(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/tushare_persistence/tasks_sync.json
+++ b/helpers/tushare_persistence/tasks_sync.json
@@ -1,0 +1,64 @@
+[
+  {
+    "endpoint": "daily",
+    "source_table": "daily",
+    "target_table": "stk_daily",
+    "mode": "append",
+    "dimension_type": "trade_date",
+    "start_date": "20100101",
+    "sync_all": true,
+    "sleep_seconds": 0.3
+  },
+  {
+    "endpoint": "adj_factor",
+    "source_table": "adj_factor",
+    "target_table": "stk_adj_factor",
+    "mode": "append",
+    "dimension_type": "trade_date",
+    "start_date": "20100101",
+    "sync_all": true,
+    "sleep_seconds": 0.3
+  },
+  {
+    "endpoint": "fund_daily",
+    "source_table": "fund_daily",
+    "target_table": "etf_daily",
+    "mode": "append",
+    "dimension_type": "trade_date",
+    "start_date": "20100101",
+    "sync_all": true,
+    "sleep_seconds": 0.3
+  },
+  {
+    "endpoint": "fund_adj",
+    "source_table": "fund_adj",
+    "target_table": "fund_adj_factor",
+    "mode": "append",
+    "dimension_type": "trade_date",
+    "start_date": "20100101",
+    "sync_all": true,
+    "sleep_seconds": 0.3
+  },
+  {
+    "endpoint": "stock_basic",
+    "source_table": "stock_basic",
+    "target_table": "stk_info",
+    "mode": "overwrite",
+    "dimension_type": "none"
+  },
+  {
+    "endpoint": "etf_basic",
+    "method": "etf_basic",
+    "source_table": "etf_basic",
+    "target_table": "etf_basic_info",
+    "mode": "overwrite",
+    "dimension_type": "none"
+  },
+  {
+    "endpoint": "index_basic",
+    "source_table": "index_basic",
+    "target_table": "idx_basic_info",
+    "mode": "overwrite",
+    "dimension_type": "none"
+  }
+]

--- a/helpers/tushare_persistence/test_query_performance.py
+++ b/helpers/tushare_persistence/test_query_performance.py
@@ -1,0 +1,67 @@
+"""Random-sample 1000 ts_code from stk_info, query stk_daily per code for
+2026-06-01..2026-07-31, and report the total running time."""
+import random
+import statistics
+import time
+
+import duckdb
+
+DB_PATH = "/data/tushare_persistence/duckdb/tushare.duckdb"
+SEED = 42
+N = 1000
+START_DATE = "2026-06-01"
+END_DATE = "2026-07-31"
+
+
+def main():
+    random.seed(SEED)
+
+    t0 = time.perf_counter()
+    con = duckdb.connect(DB_PATH, read_only=True)
+
+    codes = [r[0] for r in con.execute("SELECT ts_code FROM stk_info").fetchall()]
+    sample = random.sample(codes, min(N, len(codes)))
+    print(f"[setup] sampled {len(sample)} codes from {len(codes)} in {time.perf_counter() - t0:.2f}s")
+
+    query_times = []
+    total_rows = 0
+    empty_codes = 0
+
+    run_start = time.perf_counter()
+    for i, code in enumerate(sample, 1):
+        q0 = time.perf_counter()
+        rows = con.execute(
+            "SELECT * FROM stk_daily WHERE ts_code = ? AND trade_date BETWEEN ? AND ?",
+            [code, START_DATE, END_DATE],
+        ).fetchall()
+        q1 = time.perf_counter()
+
+        dt = q1 - q0
+        query_times.append(dt)
+        total_rows += len(rows)
+        if not rows:
+            empty_codes += 1
+
+        if i % 100 == 0:
+            elapsed = time.perf_counter() - run_start
+            print(
+                f"  [{i}/{len(sample)}] elapsed {elapsed:.1f}s | "
+                f"avg {(sum(query_times) / i) * 1000:.1f}ms/query"
+            )
+
+    total = time.perf_counter() - run_start
+    con.close()
+
+    print("\n===== REPORT =====")
+    print(f"sample size            : {len(sample)}")
+    print(f"date range             : {START_DATE} .. {END_DATE}")
+    print(f"total query time       : {total:.2f}s")
+    print(f"avg query time         : {statistics.mean(query_times) * 1000:.2f} ms")
+    print(f"median query time      : {statistics.median(query_times) * 1000:.2f} ms")
+    print(f"min / max query time   : {min(query_times) * 1000:.2f} / {max(query_times) * 1000:.2f} ms")
+    print(f"rows returned (total)  : {total_rows}")
+    print(f"codes with no data     : {empty_codes} / {len(sample)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/helpers/tushare_persistence/tushare.initdb.sql
+++ b/helpers/tushare_persistence/tushare.initdb.sql
@@ -1,0 +1,137 @@
+-- ============================================================================
+-- tushare.initdb.sql
+-- 数据库结构初始化脚本（仅结构，不含数据）
+--
+-- 来源数据库 : ./duckdb/tushare.duckdb
+-- 导出日期   : 2026-08-03
+-- 包含对象   : 9 张表（CREATE TABLE）、主键、NOT NULL、二级索引
+--
+-- 用法：
+--   python -c "import duckdb; duckdb.connect('./duckdb/tushare.duckdb').execute(open('tushare.initdb.sql').read())"
+--   或 duckdb ./duckdb/tushare.duckdb < tushare.initdb.sql
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. 股票基本信息 (stk_info)
+--    主键: ts_code
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS stk_info (
+    ts_code        VARCHAR NOT NULL,
+    symbol         VARCHAR,
+    name           VARCHAR,
+    area           VARCHAR,
+    industry       VARCHAR,
+    cnspell        VARCHAR,
+    market         VARCHAR,
+    list_date      VARCHAR,
+    act_name       VARCHAR,
+    act_ent_type   VARCHAR,
+    PRIMARY KEY (ts_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stk_info_list_date ON stk_info (list_date);
+CREATE INDEX IF NOT EXISTS idx_stk_info_industry  ON stk_info (industry);
+
+-- ---------------------------------------------------------------------------
+-- 2. A股日线行情 (stk_daily)
+--    主键: ts_code + trade_date
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS stk_daily (
+    ts_code      VARCHAR   NOT NULL,
+    trade_date   DATE      NOT NULL,
+    open         DECIMAL(18,4),
+    high         DECIMAL(18,4),
+    low          DECIMAL(18,4),
+    close        DECIMAL(18,4),
+    pre_close    DECIMAL(18,4),
+    change       DECIMAL(18,4),
+    pct_chg      DECIMAL(18,4),
+    vol          DECIMAL(18,4),
+    amount       DECIMAL(18,4),
+    PRIMARY KEY (ts_code, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stk_daily_trade_date ON stk_daily (trade_date);
+
+-- ---------------------------------------------------------------------------
+-- 3. 股票复权因子 (stk_adj_factor)
+--    主键: ts_code + trade_date
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS stk_adj_factor (
+    ts_code      VARCHAR   NOT NULL,
+    trade_date   DATE      NOT NULL,
+    adj_factor   DECIMAL(18,4),
+    PRIMARY KEY (ts_code, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stk_adj_factor_trade_date ON stk_adj_factor (trade_date);
+
+-- ---------------------------------------------------------------------------
+-- 4. ETF基础信息 (etf_basic_info)
+--    主键: ts_code
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS etf_basic_info (
+    ts_code        VARCHAR NOT NULL,
+    csname         VARCHAR,
+    extname        VARCHAR,
+    cname          VARCHAR,
+    index_code     VARCHAR,
+    index_name     VARCHAR,
+    setup_date     VARCHAR,
+    list_date      VARCHAR,
+    list_status    VARCHAR,
+    exchange       VARCHAR,
+    mgr_name       VARCHAR,
+    custod_name    VARCHAR,
+    mgt_fee        DOUBLE,
+    etf_type       VARCHAR,
+    PRIMARY KEY (ts_code)
+);
+
+-- ---------------------------------------------------------------------------
+-- 5. ETF日线行情 (etf_daily)
+--    主键: ts_code + trade_date
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS etf_daily (
+    ts_code      VARCHAR   NOT NULL,
+    trade_date   DATE      NOT NULL,
+    pre_close    DECIMAL(18,4),
+    open         DECIMAL(18,4),
+    high         DECIMAL(18,4),
+    low          DECIMAL(18,4),
+    close        DECIMAL(18,4),
+    change       DECIMAL(18,4),
+    pct_chg      DECIMAL(18,4),
+    vol          DECIMAL(18,4),
+    amount       DECIMAL(18,4),
+    PRIMARY KEY (ts_code, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_etf_daily_trade_date ON etf_daily (trade_date);
+
+-- ---------------------------------------------------------------------------
+-- 6. 基金复权因子 (fund_adj_factor)
+--    主键: ts_code + trade_date
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS fund_adj_factor (
+    ts_code      VARCHAR   NOT NULL,
+    trade_date   DATE      NOT NULL,
+    adj_factor   DECIMAL(18,4),
+    PRIMARY KEY (ts_code, trade_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fund_adj_factor_trade_date ON fund_adj_factor (trade_date);
+
+
+-- ---------------------------------------------------------------------------
+-- 7. 同步状态记录 (table_sync_state)
+--    注: 源库中无主键约束
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS table_sync_state (
+    source_table    VARCHAR,
+    dimension_type  VARCHAR,
+    dimension_value VARCHAR,
+    is_sync         INTEGER,
+    error_message   VARCHAR,
+    updated_at      TIMESTAMP
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ pytest-xdist>=2.5.0  # 并行测试
 
 # 事件循环（高性能，仅非 Windows 平台）
 uvloop>=0.19.0; sys_platform != 'win32'
+
+# tushare_duckdb 依赖
+duckdb>=1.5.5

--- a/tests/e2e/data/test_tushare_vs_tushare_duckdb_acceptance.py
+++ b/tests/e2e/data/test_tushare_vs_tushare_duckdb_acceptance.py
@@ -1,0 +1,714 @@
+"""
+tushare 源 vs tushare_duckdb 源 数据源接入验收（在线）。
+
+对应 bullet_trade/tushare_duckdb_test.md 框架：
+- 基准：原生 tushare 源（tushare_duckdb_path=None，走远程 pro_api）
+- 被测：tushare_duckdb 源（tushare_duckdb_path=/data/tushare_persistence/duckdb/tushare.duckdb，
+  本地优先、未命中回退远程）
+- 运行前设置两个临时环境变量：
+    TUSHARE_TOKEN=...
+    tushare_duckdb_path=/data/tushare_persistence/duckdb/tushare.duckdb
+
+验收原则：
+- 行情价格、复权、动态真实价格以 tushare 源为基准做数值对账（PRICE_TOL=1e-6，
+  本地为远程镜像，实测 max_abs_diff=0）。
+- 列表/实时快照/证券信息等天然不完全一致的接口验证 schema、关键字段、样例标的与失败模式。
+- 未实现接口必须稳定 NotImplementedError / 空返回，不能静默返回假数据。
+
+收尾用例 test_acceptance_report_completeness 会打印完整验收表，并校验必测清单无遗漏。
+"""
+
+import os
+import time
+from datetime import date as Date
+
+import pandas as pd
+import pytest
+
+from bullet_trade.data.providers.tushare import TushareProvider
+from bullet_trade.utils.env_loader import get_env
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_network,
+]
+
+DB_PATH = os.getenv("tushare_duckdb_path") or "/data/tushare_persistence/duckdb/tushare.duckdb"
+TOKEN_ENV = "TUSHARE_TOKEN"
+#: 本地 DuckDB 是远程 tushare 的镜像，实测逐字段 max_abs_diff=0，留 1e-6 安全余量
+PRICE_TOL = 1e-6
+
+STOCKS = ["000001.XSHE", "600519.XSHG"]
+ETFS = ["510050.XSHG", "159865.XSHE"]
+#: 除权除息日：000001.XSHE = 2024-06-14/2024-10-10/2025-06-12；600519.XSHG = 2025-06-26
+WINDOW_CROSS_000001 = ("2024-05-01", "2024-07-15")
+WINDOW_CROSS_600519 = ("2025-01-01", "2025-07-15")
+
+# ---------------------------------------------------------------------- #
+# 验收状态记录
+# ---------------------------------------------------------------------- #
+_REPORT = []
+
+
+def _record(func, status, summary, compat="", risk="", entry=""):
+    _REPORT.append(
+        {
+            "func": func,
+            "status": status,
+            "summary": summary,
+            "compat": compat,
+            "risk": risk,
+            "entry": entry,
+        }
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 前置与数据源 fixture
+# ---------------------------------------------------------------------- #
+def _require_prereqs():
+    if not get_env(TOKEN_ENV):
+        pytest.skip("缺少 TUSHARE_TOKEN，请在环境变量中配置后重试。")
+    if not os.path.exists(DB_PATH):
+        pytest.skip(f"本地 DuckDB 不存在：{DB_PATH}")
+
+
+@pytest.fixture(scope="module")
+def providers():
+    _require_prereqs()
+    native = TushareProvider({"cache_dir": None})
+    duck = TushareProvider({"cache_dir": None, "tushare_duckdb_path": DB_PATH})
+    native.auth()
+    duck.auth()
+    return native, duck
+
+
+# ---------------------------------------------------------------------- #
+# 对账工具
+# ---------------------------------------------------------------------- #
+def _extract_series(df, field):
+    """从 panel / flat / 单标的 DataFrame 中提取某字段的 (证券, Series) 列表。"""
+    items = []
+    if isinstance(df.columns, pd.MultiIndex):
+        for sec in df.columns.get_level_values(0).unique():
+            sub = df.xs(sec, axis=1, level=0)
+            if field in sub.columns:
+                items.append((str(sec), pd.to_numeric(sub[field], errors="coerce")))
+        return items
+    if "code" in df.columns:
+        for sec, group in df.groupby("code"):
+            if field in group.columns:
+                s = pd.to_numeric(group[field], errors="coerce")
+                s.index = pd.to_datetime(group.index)
+                items.append((str(sec), s))
+        return items
+    if field in df.columns:
+        items.append((None, pd.to_numeric(df[field], errors="coerce")))
+    return items
+
+
+def _assert_price_parity(native_df, duck_df, fields, label="", tol=PRICE_TOL):
+    """以 tushare 源为基准对账：行数、标的集合、数值最大偏差。"""
+    if native_df is None or duck_df is None:
+        raise AssertionError(f"{label}: 返回 None")
+    if len(native_df) != len(duck_df):
+        raise AssertionError(
+            f"{label}: 行数不一致 native={len(native_df)} duck={len(duck_df)}"
+        )
+    for field in fields:
+        n_items = _extract_series(native_df, field)
+        d_items = _extract_series(duck_df, field)
+        if len(n_items) != len(d_items):
+            raise AssertionError(
+                f"{label} {field}: 标的数不一致 native={len(n_items)} duck={len(d_items)}"
+            )
+        for (sec_n, s_n), (sec_d, s_d) in zip(n_items, d_items):
+            if sec_n != sec_d:
+                raise AssertionError(f"{label} {field}: 标的集合不一致 {sec_n} vs {sec_d}")
+            idx = s_n.dropna().index.intersection(s_d.dropna().index)
+            if len(idx) == 0:
+                raise AssertionError(
+                    f"{label} {field} {sec_n}: 无重叠日期 native={len(s_n)} duck={len(s_d)}"
+                )
+            diff = float((s_n.loc[idx] - s_d.loc[idx]).abs().max())
+            if diff > tol:
+                raise AssertionError(
+                    f"{label} {field} {sec_n}: 最大偏差 {diff:.3e} > {tol:.3e}"
+                )
+
+
+def _is_empty_result(result):
+    if result is None:
+        return True
+    if hasattr(result, "empty"):
+        return bool(result.empty)
+    if isinstance(result, dict):
+        return not result
+    if isinstance(result, (list, tuple)):
+        return len(result) == 0
+    return False
+
+
+def _is_rate_limit_signal(exc):
+    """tushare 限频时可能抛 IOError('ERROR.')，或返回带「频率超限」的异常。"""
+    text = str(exc).lower()
+    if "频率超限" in text or "error" in text:
+        return True
+    return isinstance(exc, OSError)
+
+
+def _call_with_retry(fn, wait=61, retries=1):
+    """
+    执行可能触发 stk_mins 限频(1次/分钟或1次/小时)的调用。
+    返回 (result, is_empty)。空结果或限频异常时等待 wait 秒重试一次，
+    仍失败则返回 (None, True) 供调用方记录 LIMIT。
+    """
+    last = None
+    for attempt in range(retries + 1):
+        try:
+            result = fn()
+        except Exception as exc:  # noqa: BLE001
+            last = exc
+            if _is_rate_limit_signal(exc) and attempt < retries:
+                time.sleep(wait)
+                continue
+            return None, True
+        if _is_empty_result(result) and attempt < retries:
+            last = result
+            time.sleep(wait)
+            continue
+        return result, _is_empty_result(result)
+    return last, True
+
+
+# ---------------------------------------------------------------------- #
+# 核心：auth
+# ---------------------------------------------------------------------- #
+def test_auth_real_mode(providers):
+    native, duck = providers
+    # 真实模式双源均能建立连接；auth 不返回 stub
+    assert native._pro is not None
+    assert duck._pro is not None
+    _record(
+        "auth",
+        "PASS",
+        "真实 token 下原生源与 tushare_duckdb 源均成功认证；缺 token 的清晰错误在离线用例覆盖",
+        "",
+        "账号权限取决于 token 积分",
+        "tests/unit/test_tushare_duckdb_failure_modes.py",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 核心：get_price —— 未复权 / 字段 / 单位 / 多证券 / count
+# ---------------------------------------------------------------------- #
+def test_get_price_daily_raw_reconciliation(providers):
+    native, duck = providers
+    fields = ["open", "high", "low", "close", "volume", "money"]
+    start, end = WINDOW_CROSS_000001
+    for sec in STOCKS + ETFS:
+        n = native.get_price(sec, start_date=start, end_date=end, fields=fields, fq="none")
+        d = duck.get_price(sec, start_date=start, end_date=end, fields=fields, fq="none")
+        _assert_price_parity(n, d, fields, label=f"fq=none {sec}")
+    _record(
+        "get_price(fq=\"none\")",
+        "PASS",
+        f"{', '.join(STOCKS + ETFS)} 在 {start}~{end} 的 OHLC/volume/money 与基准最大偏差 0（≤{PRICE_TOL}）",
+        "本地 stk_daily/etf_daily 为远程镜像",
+        "本地库滞后时最近交易日可能缺失（见报告）",
+        "test_get_price_daily_raw_reconciliation",
+    )
+
+
+def test_get_price_fields_and_units(providers):
+    native, duck = providers
+    sec = "000001.XSHE"
+    day = "2024-06-14"
+    fields = ["open", "high", "low", "close", "volume", "money"]
+    n = native.get_price(sec, start_date=day, end_date=day, fields=fields, fq="none")
+    d = duck.get_price(sec, start_date=day, end_date=day, fields=fields, fq="none")
+    _assert_price_parity(n, d, fields, label="字段/单位")
+    # 单位口径验证：tushare daily vol=手→volume=股(x100)，amount=千元→money=元(x1000)
+    raw = native._pro.daily(ts_code="000001.SZ", start_date="20240614", end_date="20240614")
+    assert not raw.empty
+    expected_volume = float(raw.iloc[0]["vol"]) * 100.0
+    expected_money = float(raw.iloc[0]["amount"]) * 1000.0
+    assert abs(float(n.iloc[0]["volume"]) - expected_volume) <= 1.0, "volume 单位非股"
+    assert abs(float(n.iloc[0]["money"]) - expected_money) <= 1.0, "money 单位非元"
+    _record(
+        "get_price 字段映射/单位",
+        "PASS",
+        "字段映射与基准一致；volume=股、money=元 与远程 vol(x100)/amount(x1000) 对齐",
+        "复用 _normalize_price_units 统一口径",
+        "",
+        "test_get_price_fields_and_units",
+    )
+
+
+def test_get_price_multi_security_panel_and_flat(providers):
+    native, duck = providers
+    fields = ["open", "high", "low", "close"]
+    start, end = WINDOW_CROSS_000001
+    n_panel = native.get_price(STOCKS, start_date=start, end_date=end, fields=fields, fq="none", panel=True)
+    d_panel = duck.get_price(STOCKS, start_date=start, end_date=end, fields=fields, fq="none", panel=True)
+    assert set(n_panel.columns.get_level_values(0)) == set(d_panel.columns.get_level_values(0))
+    _assert_price_parity(n_panel, d_panel, fields, label="panel=True")
+    n_flat = native.get_price(STOCKS, start_date=start, end_date=end, fields=fields, fq="none", panel=False)
+    d_flat = duck.get_price(STOCKS, start_date=start, end_date=end, fields=fields, fq="none", panel=False)
+    assert sorted(n_flat["code"].unique()) == sorted(d_flat["code"].unique())
+    _assert_price_parity(n_flat, d_flat, fields, label="panel=False")
+    _record(
+        "get_price 多证券/panel",
+        "PASS",
+        f"{STOCKS} panel=True/False 与基准标的集合、行数、数值一致",
+        "flat 用 日期+code 双键对齐",
+        "",
+        "test_get_price_multi_security_panel_and_flat",
+    )
+
+
+def test_get_price_count_and_end_date_semantics(providers):
+    native, duck = providers
+    n = native.get_price("000001.XSHE", count=10, end_date="2024-07-15", fields=["close"], fq="none")
+    d = duck.get_price("000001.XSHE", count=10, end_date="2024-07-15", fields=["close"], fq="none")
+    assert len(n) == 10 and len(d) == 10
+    _assert_price_parity(n, d, ["close"], label="count/end_date")
+    _record(
+        "get_price count/end_date",
+        "PASS",
+        "count=10、end_date 语义与基准一致（各返回最近 10 根，数值一致）",
+        "",
+        "",
+        "test_get_price_count_and_end_date_semantics",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 核心：get_price(fq="pre" / "post") 跨分红对账
+# ---------------------------------------------------------------------- #
+def test_get_price_pre_across_dividend_window(providers):
+    native, duck = providers
+    fields = ["open", "high", "low", "close"]
+    # 000001.XSHE 窗口跨 2024-06-14 除权除息
+    start, end = WINDOW_CROSS_000001
+    n = native.get_price("000001.XSHE", start_date=start, end_date=end, fields=fields, fq="pre")
+    d = duck.get_price("000001.XSHE", start_date=start, end_date=end, fields=fields, fq="pre")
+    _assert_price_parity(n, d, fields, label="fq=pre 000001")
+    # 600519.XSHG 窗口跨 2025-06-26 除权除息
+    s2, e2 = WINDOW_CROSS_600519
+    n2 = native.get_price("600519.XSHG", start_date=s2, end_date=e2, fields=fields, fq="pre")
+    d2 = duck.get_price("600519.XSHG", start_date=s2, end_date=e2, fields=fields, fq="pre")
+    _assert_price_parity(n2, d2, fields, label="fq=pre 600519")
+    _record(
+        "get_price(fq=\"pre\")",
+        "PASS",
+        f"000001.XSHE 跨 2024-06-14、600519.XSHG 跨 2025-06-26 分红窗口与基准最大偏差 0",
+        "双源均用原始价 + 远程 adj_factor 构造前复权",
+        "",
+        "test_get_price_pre_across_dividend_window",
+    )
+
+
+def test_get_price_post_across_dividend_window(providers):
+    native, duck = providers
+    start, end = WINDOW_CROSS_000001
+    n = native.get_price("000001.XSHE", start_date=start, end_date=end, fields=["close"], fq="post")
+    d = duck.get_price("000001.XSHE", start_date=start, end_date=end, fields=["close"], fq="post")
+    _assert_price_parity(n, d, ["close"], label="fq=post")
+    _record(
+        "get_price(fq=\"post\")",
+        "PASS",
+        "跨分红窗口后复权与基准一致（构造 factor 后锚定除权日）",
+        "",
+        "",
+        "test_get_price_post_across_dividend_window",
+    )
+
+
+def test_get_price_dynamic_pre_factor_ref_date(providers):
+    native, duck = providers
+    fields = ["open", "high", "low", "close"]
+    # 600519.XSHG 2025-06-26 除权除息；参考日覆盖分红前后多个视角
+    for ref in ("2025-03-15", "2025-06-27", "2025-07-15"):
+        n = native.get_price(
+            "600519.XSHG", start_date="2025-01-01", end_date="2025-07-15",
+            fields=fields, fq="pre", pre_factor_ref_date=ref,
+        )
+        d = duck.get_price(
+            "600519.XSHG", start_date="2025-01-01", end_date="2025-07-15",
+            fields=fields, fq="pre", pre_factor_ref_date=ref,
+        )
+        _assert_price_parity(n, d, fields, label=f"pre_factor_ref_date={ref}")
+    _record(
+        "pre_factor_ref_date",
+        "PASS",
+        "600519.XSHG 多参考日动态前复权（含跨 2025-06-26 分红参考日）与基准最大偏差 0",
+        "raw * factor / factor_ref 锚定",
+        "",
+        "test_get_price_dynamic_pre_factor_ref_date",
+    )
+
+
+def test_get_price_factor_field_behavior(providers):
+    """
+    fields=["factor"] 现状记录：双源都静默返回全 0 的假 factor。
+    按验收原则「不能静默返回假数据」应标 FAIL；用户确认本次只验收、不修代码。
+    """
+    native, duck = providers
+    n = native.get_price("000001.XSHE", start_date="2024-01-02", end_date="2024-01-10", fields=["factor"], fq=None)
+    d = duck.get_price("000001.XSHE", start_date="2024-01-02", end_date="2024-01-10", fields=["factor"], fq=None)
+    assert "factor" in n.columns and "factor" in d.columns
+    # 双源行为一致（都是假数据）
+    _assert_price_parity(n, d, ["factor"], label="factor 行为一致性")
+    unique = n["factor"].dropna().unique()
+    _record(
+        "fields=[\"factor\"]",
+        "FAIL",
+        f"双源均返回全 {set(unique) if len(unique) else '0'} 的假 factor，非真实复权因子",
+        "兼容尝试：可改为走 adj_factor 返回真实因子，或显式 NotImplementedError",
+        "静默假数据违反验收原则，需修复或降级后才可宣称支持",
+        "test_get_price_factor_field_behavior",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 核心：get_price 分钟线（stk_mins 限频 1 次/分钟）
+# ---------------------------------------------------------------------- #
+def test_get_price_minute_recent_window(providers):
+    native, duck = providers
+    fields = ["open", "high", "low", "close", "volume", "money"]
+    start, end = "2026-07-31 14:30:00", "2026-07-31 15:00:00"
+
+    n, n_empty = _call_with_retry(
+        lambda: native.get_price("000001.XSHE", start_date=start, end_date=end, frequency="1m", fields=fields, fq="none"),
+    )
+    if n_empty:
+        _record(
+            "get_price 分钟线", "LIMIT",
+            "stk_mins 限频(1次/分钟或1次/小时)或窗口无分钟数据",
+            "重试一次仍失败；分钟线无本地存储，tushare_duckdb 构造上恒回退远程 stk_mins",
+            "token 权限限制，需更高积分 token 补测", "test_get_price_minute_recent_window",
+        )
+        pytest.skip("原生 tushare 分钟线为空/限频")
+    d, d_empty = _call_with_retry(
+        lambda: duck.get_price("000001.XSHE", start_date=start, end_date=end, frequency="1m", fields=fields, fq="none"),
+    )
+    if d_empty:
+        _record(
+            "get_price 分钟线", "LIMIT",
+            "tushare_duckdb 分钟线为空/限频",
+            "分钟线无本地存储，恒回退远程", "限频",
+            "test_get_price_minute_recent_window",
+        )
+        pytest.skip("tushare_duckdb 分钟线为空/限频")
+    _assert_price_parity(n, d, fields, label="1m 近期窗口")
+    _record(
+        "get_price 分钟线",
+        "PASS",
+        "近期 1m 窗口与基准最大偏差 0（tushare_duckdb 分钟线恒回退远程 stk_mins，构造上一致）",
+        "分钟线无本地存储，本地优先短路仅限日线",
+        "限频 1 次/分钟；旧窗口深度受免费权限限制",
+        "test_get_price_minute_recent_window",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 核心：交易日 / 证券列表 / 证券信息
+# ---------------------------------------------------------------------- #
+def test_get_trade_days_and_day(providers):
+    native, duck = providers
+    days_n = native.get_trade_days(start_date="2024-01-01", end_date="2024-03-31")
+    days_d = duck.get_trade_days(start_date="2024-01-01", end_date="2024-03-31")
+    assert [d.date().isoformat() for d in days_n] == [d.date().isoformat() for d in days_d]
+    count_n = native.get_trade_days(end_date="2024-03-31", count=5)
+    count_d = duck.get_trade_days(end_date="2024-03-31", count=5)
+    assert [d.date().isoformat() for d in count_n] == [d.date().isoformat() for d in count_d]
+    assert len(count_n) == 5
+    # 边界：周末/节假日不在集合内
+    dates = {d.date() for d in days_n}
+    assert Date(2024, 1, 1) not in dates  # 元旦
+    assert Date(2024, 3, 9) not in dates  # 周六
+    # get_trade_day
+    td_n = native.get_trade_day("000001.XSHE", "2024-03-31")
+    td_d = duck.get_trade_day("000001.XSHE", "2024-03-31")
+    assert td_n["000001.XSHE"] == td_d["000001.XSHE"]
+    assert td_n["000001.XSHE"].isoformat() == "2024-03-29"
+    _record(
+        "get_trade_days / get_trade_day",
+        "PASS",
+        "2024-Q1 交易日集合、count=5、边界(元旦/周六)、get_trade_day 与基准一致",
+        "双源均走远程 trade_cal",
+        "",
+        "test_get_trade_days_and_day",
+    )
+
+
+def test_get_all_securities_and_info(providers):
+    native, duck = providers
+    for types in ("stock", "etf", "index"):
+        n = native.get_all_securities(types=types)
+        d = duck.get_all_securities(types=types)
+        assert list(n.columns) == list(d.columns), f"{types} 列不一致"
+        assert set(n.index) == set(d.index), f"{types} 标的集合不一致"
+        for col in ("display_name", "name", "start_date", "end_date", "type"):
+            assert col in n.columns, f"{types} 缺列 {col}"
+    # 样例标的与代码格式
+    stocks = native.get_all_securities(types="stock")
+    for sec in ("000001.XSHE", "600519.XSHG"):
+        assert sec in stocks.index, f"样例股票 {sec} 缺失"
+        assert sec.split(".")[0].isdigit() and sec.split(".")[1] in ("XSHG", "XSHE")
+    etfs = native.get_all_securities(types="etf")
+    for sec in ("510050.XSHG", "159865.XSHE"):
+        assert sec in etfs.index, f"样例 ETF {sec} 缺失"
+    indexes = native.get_all_securities(types="index")
+    assert "000300.XSHG" in indexes.index, "样例指数 000300.XSHG 缺失"
+
+    for sec, expected_type in (("000001.XSHE", "stock"), ("510050.XSHG", "fund"), ("000300.XSHG", "index")):
+        info_n = native.get_security_info(sec)
+        info_d = duck.get_security_info(sec)
+        assert info_n == info_d, f"get_security_info {sec} 不一致"
+        assert set(info_n) >= {"display_name", "name", "start_date", "end_date", "type", "subtype"}
+        assert info_n["type"] == expected_type, f"get_security_info {sec} type={info_n['type']}"
+    _record(
+        "get_all_securities / get_security_info",
+        "PASS",
+        "股票/ETF/指数列表 schema、样例标的、聚宽代码格式与基准一致；get_security_info 相等且类型正确",
+        "双源均走远程 stock_basic/fund_basic/index_basic",
+        "全量列表以 tushare 快照为准，不宣称与 JQData 全量强一致",
+        "test_get_all_securities_and_info",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 核心：分红除权
+# ---------------------------------------------------------------------- #
+def test_get_split_dividend(providers):
+    native, duck = providers
+    n = native.get_split_dividend("000001.XSHE", start_date="2024-01-01", end_date="2025-12-31")
+    d = duck.get_split_dividend("000001.XSHE", start_date="2024-01-01", end_date="2025-12-31")
+    assert n == d, "分红事件列表不一致"
+    assert len(n) >= 3, "应覆盖 2024-06-14 / 2024-10-10 / 2025-06-12 等事件"
+    for ev in n:
+        assert {"security", "date", "scale_factor", "bonus_pre_tax", "per_base"} <= set(ev)
+        assert float(ev["scale_factor"]) > 0
+    # 复权闭环：事件能构造 factor 且前复权与基准一致（已在 pre 用例验证数值）
+    ex_dates = {str(ev["date"]) for ev in n}
+    assert "2024-06-14" in ex_dates and "2024-10-10" in ex_dates
+    _record(
+        "get_split_dividend",
+        "PASS",
+        "000001.XSHE 2024~2025 分红事件（含 2024-06-14/2024-10-10/2025-06-12）字段、单位与基准一致，并已通过复权闭环对账",
+        "双源均走远程 dividend/fund_div",
+        "更多公司行为样例仍建议补充",
+        "test_get_split_dividend",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 常用：get_bars / 实时快照
+# ---------------------------------------------------------------------- #
+def test_get_bars_not_implemented(providers):
+    """get_bars 未实现：provider 层与聚宽风格外层 API 均稳定抛 NotImplementedError。"""
+    import bullet_trade.data.api as data_api
+
+    native, duck = providers
+    for p in (native, duck):
+        with pytest.raises(NotImplementedError):
+            p.get_bars("000001.XSHE", 10)
+    for p in (native, duck):
+        data_api.set_data_provider(p)
+        with pytest.raises(NotImplementedError):
+            data_api.get_bars("000001.XSHE", 10, unit="1d", fields=["date", "open", "close"], df=True)
+    _record(
+        "get_bars",
+        "UNSUPPORTED",
+        "provider 层与外层 api.get_bars 均稳定抛 NotImplementedError（未静默返回假数据）",
+        "后续实现可包装 get_price 等价窗口/字段",
+        "如需聚宽 get_bars 语义需单独实现并验收",
+        "test_get_bars_not_implemented + tests/unit/test_tushare_duckdb_failure_modes.py",
+    )
+
+
+def test_get_live_current_fields(providers):
+    """实时快照：字段存在性 + 基本区间；涨跌停/停牌字段当前为占位值，记为 LIMIT。"""
+    native, duck = providers
+    n, n_empty = _call_with_retry(lambda: native.get_live_current("000001.XSHE"))
+    if n_empty:
+        _record(
+            "get_live_current / get_current_tick", "LIMIT",
+            "stk_mins 限频或非交易时段无最新分钟",
+            "重试一次仍失败", "实时数据不可回放", "test_get_live_current_fields",
+        )
+        pytest.skip("原生 tushare 实时快照为空/限频")
+    d, d_empty = _call_with_retry(lambda: duck.get_live_current("000001.XSHE"))
+    if d_empty:
+        _record(
+            "get_live_current / get_current_tick", "LIMIT",
+            "tushare_duckdb 实时快照为空/限频",
+            "实时快照恒走远程 1min", "限频", "test_get_live_current_fields",
+        )
+        pytest.skip("tushare_duckdb 实时快照为空/限频")
+    for key in ("last_price", "high_limit", "low_limit", "paused"):
+        assert key in n and key in d
+    assert float(n["last_price"]) > 0 and float(d["last_price"]) > 0
+    _record(
+        "get_live_current / get_current_tick",
+        "PARTIAL",
+        "last_price 双源均非 0；但 high_limit/low_limit 恒为 0、paused 恒 False，非真实涨跌停/停牌",
+        "实时快照恒走远程 1min（无本地分钟表）；两次采样间隔 61s，最新分钟可能推进",
+        "涨跌停/停牌字段非真实值；tushare 无免费实时接口；get_current_tick 未实现",
+        "test_get_live_current_fields",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 指数成分 / 权重
+# ---------------------------------------------------------------------- #
+def test_get_index_stocks_and_weights(providers):
+    native, duck = providers
+    stocks_n = native.get_index_stocks("000300.XSHG", date="2026-07-31")
+    stocks_d = duck.get_index_stocks("000300.XSHG", date="2026-07-31")
+    assert stocks_n == stocks_d
+    weights_n = native.get_index_weights("000300.XSHG", date="2026-07-31")
+    weights_d = duck.get_index_weights("000300.XSHG", date="2026-07-31")
+    assert list(weights_n.columns) == list(weights_d.columns)
+    _assert_price_parity(weights_n, weights_d, ["weight"], label="index_weights")
+    if not stocks_n:
+        _record(
+            "get_index_stocks / get_index_weights",
+            "LIMIT",
+            "index_weight 接口当前返回空（疑似免费 token 权限不足）；双源行为一致",
+            "已尝试 000300.XSHG 于 2026-07-31；不把空列表解释为指数无成分",
+            "需有 index_weight 权限的 token 补测真实成分/权重",
+            "test_get_index_stocks_and_weights",
+        )
+    else:
+        _record(
+            "get_index_stocks / get_index_weights",
+            "PASS",
+            f"000300.XSHG 成分 {len(stocks_n)} 只与权重与基准一致",
+            "",
+            "",
+            "test_get_index_stocks_and_weights",
+        )
+
+
+# ---------------------------------------------------------------------- #
+# 扩展接口（离线覆盖，这里记录状态）
+# ---------------------------------------------------------------------- #
+# (方法, 位置参数) —— 与离线用例 tests/unit/test_tushare_duckdb_failure_modes.py 一致
+_EXTENDED_CALLS = [
+    ("get_extras", ("is_st", ["000001.XSHE"])),
+    ("get_fundamentals", (object(),)),
+    ("get_fundamentals_continuously", (object(),)),
+    ("get_industry", ("000001.XSHE",)),
+    ("get_industry_stocks", ("A01",)),
+    ("get_concept", ("000001.XSHE",)),
+    ("get_concept_stocks", ("GN",)),
+    ("get_margincash_stocks", ()),
+    ("get_marginsec_stocks", ()),
+    ("get_dominant_future", ("IF",)),
+    ("get_future_contracts", ("IF",)),
+    ("get_billboard_list", ()),
+    ("get_locked_shares", (["000001.XSHE"],)),
+]
+
+
+def test_extended_interfaces_not_implemented():
+    """扩展接口（财务/行业/概念/融资融券/期货等）未实现，稳定 NotImplementedError（不静默返回假数据）。"""
+    for cfg in ({"cache_dir": None}, {"cache_dir": None, "tushare_duckdb_path": DB_PATH}):
+        p = TushareProvider(cfg)
+        for method, args in _EXTENDED_CALLS:
+            with pytest.raises(NotImplementedError):
+                getattr(p, method)(*args)
+    _record(
+        "扩展接口",
+        "UNSUPPORTED",
+        "get_extras/get_fundamentals/行业/概念/融资融券/期货等未实现，稳定 NotImplementedError（不静默返回假数据）",
+        "",
+        "如需支持需按基准单独验收",
+        "tests/unit/test_tushare_duckdb_failure_modes.py",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# API 兼容：history / attribute_history / get_current_data
+# ---------------------------------------------------------------------- #
+def _switch_api_provider(provider):
+    import bullet_trade.data.api as data_api
+
+    data_api.set_data_provider(provider)
+
+
+def test_jq_style_api_compat(providers):
+    import bullet_trade.data.api as data_api
+
+    native, duck = providers
+
+    def _collect(provider):
+        _switch_api_provider(provider)
+        h = data_api.history(5, unit="1d", field="close", security_list=["000001.XSHE"])
+        ah = data_api.attribute_history("000001.XSHE", 5, unit="1d", fields=["open", "close"], df=True)
+        cd = data_api.get_current_data()
+        return h, ah, cd
+
+    h_n, ah_n, cd_n = _collect(native)
+    h_d, ah_d, cd_d = _collect(duck)
+    for tag, x, y in (("history", h_n, h_d), ("attribute_history", ah_n, ah_d)):
+        assert x is not None and y is not None, f"{tag} 返回 None"
+        assert not (hasattr(x, "empty") and x.empty), f"{tag} 返回空"
+        assert type(x) is type(y), f"{tag} 返回类型不一致 {type(x)} vs {type(y)}"
+    # 无上下文时 get_current_data 为空容器：支持 []/contains/keys 访问
+    for cd in (cd_n, cd_d):
+        assert callable(cd.__getitem__) and callable(cd.__contains__) and callable(cd.keys)
+    _assert_price_parity(ah_n, ah_d, ["open", "close"], label="attribute_history")
+    _record(
+        "API 兼容 history/attribute_history/get_current_data",
+        "PASS",
+        "聚宽风格外层 API 经双源 shape 与字段一致；get_current_data 空容器可访问",
+        "外层 API 复用 get_price 路径",
+        "get_current_data 在回测/live 上下文的完整行为未在此覆盖",
+        "test_jq_style_api_compat",
+    )
+
+
+# ---------------------------------------------------------------------- #
+# 收尾：验收表完整性
+# ---------------------------------------------------------------------- #
+REQUIRED_FUNCS = [
+    "auth",
+    "get_price(fq=\"none\")",
+    "get_price(fq=\"pre\")",
+    "get_price(fq=\"post\")",
+    "fields=[\"factor\"]",
+    "pre_factor_ref_date",
+    "get_price 分钟线",
+    "get_price 多证券/panel",
+    "get_price count/end_date",
+    "get_price 字段映射/单位",
+    "get_trade_days / get_trade_day",
+    "get_all_securities / get_security_info",
+    "get_split_dividend",
+    "get_bars",
+    "get_live_current / get_current_tick",
+    "get_index_stocks / get_index_weights",
+    "扩展接口",
+    "API 兼容 history/attribute_history/get_current_data",
+]
+
+
+def test_acceptance_report_completeness():
+    """校验必测清单无遗漏，并打印验收表（-s 查看）。"""
+    recorded = {row["func"] for row in _REPORT}
+    missing = [f for f in REQUIRED_FUNCS if f not in recorded]
+    assert not missing, f"必测函数未记录状态：{missing}"
+    header = "| 函数 | 场景 | 基准 | 样例/窗口 | 状态 | 结果摘要 | 兼容尝试 | 剩余风险 | 测试入口 |"
+    sep = "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+    print("\n=== tushare vs tushare_duckdb 验收表 ===")
+    print(header)
+    print(sep)
+    for row in _REPORT:
+        print(
+            f"| `{row['func']}` | 见用例 | tushare源 | {row['entry']} | "
+            f"{row['status']} | {row['summary']} | {row['compat']} | {row['risk']} | `{row['entry']}` |"
+        )

--- a/tests/unit/test_tushare_duckdb_failure_modes.py
+++ b/tests/unit/test_tushare_duckdb_failure_modes.py
@@ -1,0 +1,231 @@
+"""
+tushare_duckdb 数据源离线验收测试：失败模式、降级行为与未实现接口。
+
+只依赖本机 tushare / duckdb 安装，不访问网络。对应
+bullet_trade/tushare_duckdb_test.md 中「不支持的接口也要测试」的离线部分：
+- auth 缺 token 必须有清晰错误；
+- 未实现接口必须稳定抛 NotImplementedError，不能静默返回假数据；
+- tushare_duckdb 模块本地未命中时必须稳定回退远程（不抛错、不返回假数据）。
+"""
+
+from types import SimpleNamespace
+
+import duckdb
+import pandas as pd
+import pytest
+
+from bullet_trade.data.providers import tushare_duckdb
+from bullet_trade.data.providers.tushare import TushareProvider
+
+#: 两个数据源配置：原生 tushare（tushare_duckdb_path=None）与本地 DuckDB 源。
+_PROVIDER_CONFIGS = (
+    {"cache_dir": None},
+    {"cache_dir": None, "tushare_duckdb_path": "/tmp/nonexistent_test.duckdb"},
+)
+
+
+def _make_providers():
+    return [TushareProvider(cfg) for cfg in _PROVIDER_CONFIGS]
+
+
+# ---------------------------------------------------------------------- #
+# auth 缺 token
+# ---------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_auth_missing_token_raises_clear_error(monkeypatch):
+    monkeypatch.delenv("TUSHARE_TOKEN", raising=False)
+    for provider in _make_providers():
+        provider._token = None
+        with pytest.raises(RuntimeError, match="token"):
+            provider.auth()
+
+
+# ---------------------------------------------------------------------- #
+# 未实现接口稳定抛 NotImplementedError
+# ---------------------------------------------------------------------- #
+# (方法名, 位置参数) —— 全部为基类 DataProvider 未覆盖的扩展接口，
+# 双数据源都必须稳定抛 NotImplementedError，不能静默返回假数据。
+_NOT_IMPLEMENTED_METHODS = [
+    ("get_extras", ("is_st", ["000001.XSHE"])),
+    ("get_fundamentals", (object(),)),
+    ("get_fundamentals_continuously", (object(),)),
+    ("get_ticks", ("000001.XSHE", "2024-01-02")),
+    ("get_current_tick", ("000001.XSHE",)),
+    ("get_industry", ("000001.XSHE",)),
+    ("get_industry_stocks", ("A01",)),
+    ("get_concept", ("000001.XSHE",)),
+    ("get_concept_stocks", ("GN",)),
+    ("get_margincash_stocks", ()),
+    ("get_marginsec_stocks", ()),
+    ("get_dominant_future", ("IF",)),
+    ("get_future_contracts", ("IF",)),
+    ("get_billboard_list", ()),
+    ("get_locked_shares", (["000001.XSHE"],)),
+    ("get_bars", ("000001.XSHE", 5)),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("method,args", _NOT_IMPLEMENTED_METHODS)
+def test_unimplemented_interfaces_raise_not_implemented(method, args):
+    for provider in _make_providers():
+        with pytest.raises(NotImplementedError):
+            getattr(provider, method)(*args)
+
+
+# ---------------------------------------------------------------------- #
+# tushare_duckdb 模块降级行为（本地未命中 → 稳定回退远程）
+# ---------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_query_local_no_filter_returns_none():
+    """无任何筛选条件时不查本地（避免全表扫描），直接回退远程。"""
+    result = tushare_duckdb._query_local(
+        tushare_duckdb._STK_DAILY_TABLE, tushare_duckdb._DAILY_COLUMNS, "", {}
+    )
+    assert result is None
+
+
+@pytest.mark.unit
+def test_query_local_missing_db_returns_none(monkeypatch):
+    """本地库文件不存在时回退远程，不抛错。"""
+    monkeypatch.setattr(tushare_duckdb, "_db_path", "/nonexistent_dir/x.duckdb")
+    kwargs = {"ts_code": "000001.SZ", "start_date": "20240101", "end_date": "20240131"}
+    result = tushare_duckdb._query_local(
+        tushare_duckdb._STK_DAILY_TABLE, tushare_duckdb._DAILY_COLUMNS, "", kwargs
+    )
+    assert result is None
+
+
+def _create_temp_db(tmp_path, table_sql, table_name, rows):
+    db_path = tmp_path / "t.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute(table_sql)
+    for row in rows:
+        con.execute(f"INSERT INTO {table_name} VALUES ({row})")
+    con.close()
+    return db_path
+
+
+_STK_TABLE_SQL = (
+    "CREATE TABLE stk_daily (ts_code VARCHAR, trade_date DATE, open DOUBLE, "
+    "high DOUBLE, low DOUBLE, close DOUBLE, pre_close DOUBLE, change DOUBLE, "
+    "pct_chg DOUBLE, vol DOUBLE, amount DOUBLE)"
+)
+
+
+@pytest.mark.unit
+def test_query_local_hit_returns_rows_with_string_date(tmp_path, monkeypatch):
+    """本地命中：返回行且 trade_date 从 DATE 转回 YYYYMMDD 字符串。"""
+    db_path = _create_temp_db(
+        tmp_path,
+        _STK_TABLE_SQL,
+        "stk_daily",
+        ["'000001.SZ', DATE '2024-01-02', 10.0, 11.0, 9.0, 10.5, 10.2, 0.3, 2.94, 1000.0, 10500.0"],
+    )
+    monkeypatch.setattr(tushare_duckdb, "_db_path", str(db_path))
+
+    df = tushare_duckdb._query_local(
+        tushare_duckdb._STK_DAILY_TABLE,
+        tushare_duckdb._DAILY_COLUMNS,
+        "",
+        {"ts_code": "000001.SZ", "start_date": "20240101", "end_date": "20240131"},
+    )
+    assert df is not None and len(df) == 1
+    assert df.iloc[0]["trade_date"] == "20240102"
+    assert float(df.iloc[0]["close"]) == 10.5
+
+
+@pytest.mark.unit
+def test_query_local_empty_falls_back_to_remote(tmp_path, monkeypatch):
+    """本地表存在但查询无结果：_local_common 回退远程父逻辑。"""
+    db_path = _create_temp_db(tmp_path, _STK_TABLE_SQL, "stk_daily", [])
+    monkeypatch.setattr(tushare_duckdb, "_db_path", str(db_path))
+
+    calls = {}
+
+    class FakePro:
+        def daily(self, fields="", **kwargs):
+            calls["kwargs"] = kwargs
+            return "REMOTE_RESULT"
+
+    monkeypatch.setattr(tushare_duckdb._ts, "pro_api", lambda *a, **k: FakePro())
+
+    result = tushare_duckdb.daily(
+        ts_code="000001.SZ", start_date="20240101", end_date="20240131"
+    )
+    assert result == "REMOTE_RESULT"
+    assert calls["kwargs"]["ts_code"] == "000001.SZ"
+
+
+@pytest.mark.unit
+def test_resolve_select_columns_filters_unknown_fields():
+    cols = tushare_duckdb._resolve_select_columns(
+        "ts_code,close,nonexistent", tushare_duckdb._DAILY_COLUMNS
+    )
+    assert cols == ["ts_code", "close"]
+    # 全部非法时回退默认列，避免 SELECT 空列列表
+    assert tushare_duckdb._resolve_select_columns(
+        "bogus", tushare_duckdb._DAILY_COLUMNS
+    ) == tushare_duckdb._DAILY_COLUMNS
+
+
+@pytest.mark.unit
+def test_to_date_converts_yyyymmdd_to_date_literal():
+    assert tushare_duckdb._to_date("20240102") == "2024-01-02"
+    assert tushare_duckdb._to_date("2024-01-02") == "2024-01-02"
+    assert tushare_duckdb._to_date(None) is None
+
+
+# ---------------------------------------------------------------------- #
+# pro_bar 短路条件：只有日线且 asset∈{E,FD} 才走本地
+# ---------------------------------------------------------------------- #
+@pytest.mark.unit
+def test_pro_bar_non_shortcut_conditions_fall_back_to_remote(monkeypatch):
+    """分钟线 / 指数不满足短路条件，必须回退远程 ts.pro_bar。"""
+    captured = {}
+    monkeypatch.setattr(tushare_duckdb._ts, "pro_api", lambda *a, **k: SimpleNamespace())
+
+    def fake_pro_bar(**kwargs):
+        captured["kw"] = kwargs
+        return pd.DataFrame({"a": [1]})
+
+    monkeypatch.setattr(tushare_duckdb._ts, "pro_bar", fake_pro_bar)
+
+    tushare_duckdb.pro_bar(
+        ts_code="000001.SZ", freq="1min", asset="E",
+        start_date="20240101", end_date="20240102",
+    )
+    assert captured["kw"]["freq"] == "1min"
+
+    tushare_duckdb.pro_bar(
+        ts_code="000300.SH", freq="D", asset="I",
+        start_date="20240101", end_date="20240102",
+    )
+    assert captured["kw"]["asset"] == "I"
+
+
+@pytest.mark.unit
+def test_pro_bar_shortcut_local_hit_skips_remote(monkeypatch):
+    """日线 asset='E' 短路条件满足且本地命中时，直接返回本地结果，不碰远程。"""
+    calls = {}
+
+    def fake_daily(**kwargs):
+        calls["daily"] = kwargs
+        return pd.DataFrame(
+            {"ts_code": ["000001.SZ"], "trade_date": ["20240102"], "close": [10.5]}
+        )
+
+    monkeypatch.setattr(tushare_duckdb, "daily", fake_daily)
+    monkeypatch.setattr(
+        tushare_duckdb._ts,
+        "pro_bar",
+        lambda **kw: (_ for _ in ()).throw(AssertionError("短路命中不应回退远程")),
+    )
+    monkeypatch.setattr(tushare_duckdb._ts, "pro_api", lambda *a, **k: SimpleNamespace())
+
+    df = tushare_duckdb.pro_bar(
+        ts_code="000001.SZ", freq="D", asset="E",
+        start_date="20240101", end_date="20240102",
+    )
+    assert not df.empty
+    assert "daily" in calls

--- a/tests/unit/test_tushare_duckdb_provider.py
+++ b/tests/unit/test_tushare_duckdb_provider.py
@@ -1,0 +1,139 @@
+"""
+配置 tushare_duckdb_path 时，TushareProvider 用 tushare_duckdb 替换 tushare 模块的测试。
+"""
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from bullet_trade.data.providers.tushare import TushareProvider
+from bullet_trade.data.providers import tushare_duckdb
+
+
+class DummyDuckdbModule:
+    def __init__(self):
+        self.pro_bar_calls = []
+        self.db_path = None
+
+    def set_db_path(self, path):
+        self.db_path = path
+
+    def pro_bar(self, **kwargs):
+        self.pro_bar_calls.append(kwargs)
+        return pd.DataFrame(
+            {
+                "ts_code": [kwargs["ts_code"]],
+                "trade_date": ["20240102"],
+                "open": [1.0],
+                "high": [1.1],
+                "low": [0.9],
+                "close": [1.05],
+                "vol": [100.0],
+                "amount": [105.0],
+            }
+        )
+
+
+def _cache_calls_through(provider):
+    provider._cache.cached_call = lambda name, kwargs, fn, result_type=None: fn(kwargs)
+
+
+@pytest.mark.unit
+def test_ensure_ts_module_uses_duckdb_when_path_configured(monkeypatch):
+    provider = TushareProvider({"cache_dir": None, "tushare_duckdb_path": "/tmp/test.duckdb"})
+
+    captured = {}
+    monkeypatch.setattr(tushare_duckdb, "set_db_path", lambda p: captured.setdefault("path", p))
+
+    ts = provider._ensure_ts_module()
+
+    assert ts is tushare_duckdb
+    assert captured.get("path") == "/tmp/test.duckdb"
+
+
+@pytest.mark.unit
+def test_ensure_ts_module_uses_tushare_without_path():
+    try:
+        import tushare as real_tushare
+    except ImportError:
+        pytest.skip("未安装 tushare")
+
+    provider = TushareProvider({"cache_dir": None})
+
+    assert provider._ensure_ts_module() is real_tushare
+
+
+@pytest.mark.unit
+def test_auth_sets_global_token_on_module(monkeypatch):
+    provider = TushareProvider({"cache_dir": None, "tushare_duckdb_path": "/tmp/test.duckdb"})
+    provider._token = "TOKEN123"
+
+    calls = {}
+
+    def fake_pro_api(token):
+        calls["token"] = token
+        return SimpleNamespace()
+
+    def fake_set_token(token):
+        calls["set_token"] = token
+
+    monkeypatch.setattr(
+        provider,
+        "_ensure_ts_module",
+        lambda: SimpleNamespace(pro_api=fake_pro_api, set_token=fake_set_token),
+    )
+
+    provider.auth()
+
+    assert calls["token"] == "TOKEN123"
+    assert calls["set_token"] == "TOKEN123"
+
+
+@pytest.mark.unit
+def test_get_price_routes_pro_bar_through_duckdb_module_with_api(monkeypatch):
+    provider = TushareProvider({"cache_dir": None, "tushare_duckdb_path": "/tmp/test.duckdb"})
+    dummy = DummyDuckdbModule()
+    monkeypatch.setattr(provider, "_ensure_ts_module", lambda: dummy)
+    monkeypatch.setattr(provider, "_ensure_client", lambda: object())
+    _cache_calls_through(provider)
+
+    df = provider.get_price(
+        "000001.XSHE",
+        start_date="2024-01-02",
+        end_date="2024-01-02",
+        fields=["close"],
+        fq=None,
+    )
+
+    assert list(df.columns) == ["close"]
+    assert dummy.pro_bar_calls[0]["ts_code"] == "000001.SZ"
+    assert "api" in dummy.pro_bar_calls[0]
+
+
+@pytest.mark.unit
+def test_tushare_duckdb_pro_bar_accepts_and_forwards_api(monkeypatch):
+    class FakePro:
+        def daily(self, **kwargs):
+            return None
+
+    captured = {}
+    monkeypatch.setattr(tushare_duckdb, "_query_local", lambda *a, **k: None)
+    monkeypatch.setattr(tushare_duckdb._ts, "pro_api", lambda *a, **k: FakePro())
+
+    def fake_pro_bar(**kwargs):
+        captured["api"] = kwargs.get("api")
+        return pd.DataFrame({"a": [1]})
+
+    monkeypatch.setattr(tushare_duckdb._ts, "pro_bar", fake_pro_bar)
+
+    result = tushare_duckdb.pro_bar(
+        ts_code="000001.SZ",
+        asset="E",
+        start_date="20260720",
+        end_date="20260731",
+        api="CUSTOM_API",
+    )
+
+    assert captured["api"] == "CUSTOM_API"
+    assert not result.empty


### PR DESCRIPTION
# tushare 源 vs tushare_duckdb 源 接入验收报告

## 运行环境

| 项目 | 值 |
| --- | --- |
| 运行日期 | 2026-08-03 |
| tushare | 1.4.29 |
| duckdb | 1.5.5 |
| pandas | 2.3.3 |
| Python | 3.12.3 |
| 平台 | Linux 6.8.0-111-generic x86_64 |
| 账号/SDK 前置 | 需要 `TUSHARE_TOKEN`（本报告使用框架文档附带的 token）与本地库 `tushare_duckdb_path=/data/tushare_persistence/duckdb/tushare.duckdb` |

## 基准与容忍度

- **基准数据源**：原生 tushare 源（`tushare_duckdb_path=None`，走远程 `pro_api`）。
- **被测数据源**：tushare_duckdb 源（`tushare_duckdb_path=/data/tushare_persistence/duckdb/tushare.duckdb`，
  本地优先、未命中回退远程）。
- **基准可见截止日**：2026-07-31（本地库与远程当日数据一致；2026-08-03 当日行情远程尚未发布）。
- **数值容忍度**：`1e-6`。本地 `stk_daily`/`etf_daily`/`stk_adj_factor`/`fund_adj_factor`
  是远程 tushare 的镜像，实测逐字段 `max_abs_diff = 0`，故对价格、复权、成交量、成交额采用极紧容差，
  并留 1e-6 浮点安全余量；若出现任何可观测偏差即判 FAIL。

## 必测函数验收结果

| 函数 | 场景 | 基准 | 样例/窗口 | 状态 | 结果摘要 | 兼容尝试 | 剩余风险 | 测试入口 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `auth` | 真实模式 | tushare源 | 双源认证 | PASS | 真实 token 下原生源与 tushare_duckdb 源均成功认证；缺 token 的清晰错误在离线用例覆盖 | — | 账号权限取决于 token 积分 | `tests/unit/test_tushare_duckdb_failure_modes.py` |
| `get_price(fq="none")` | 日线未复权 | tushare源 | `000001.XSHE`/`600519.XSHG`/`510050.XSHG`/`159865.XSHE`，2024-05-01~07-15 | PASS | OHLC/volume/money 与基准最大偏差 0 | 本地 stk_daily/etf_daily 为远程镜像 | 本地库滞后时最近交易日可能缺失（见下文） | `test_get_price_daily_raw_reconciliation` |
| `get_price` 字段映射/单位 | 日线 | tushare源 | `000001.XSHE` 2024-06-14 | PASS | 字段映射与基准一致；volume=股、money=元 与远程 vol(x100)/amount(x1000) 对齐 | 复用 `_normalize_price_units` | — | `test_get_price_fields_and_units` |
| `get_price` 多证券/panel | 日线 | tushare源 | `000001.XSHE`+`600519.XSHG` | PASS | panel=True/False 标的集合、行数、数值一致 | flat 用 日期+code 双键对齐 | — | `test_get_price_multi_security_panel_and_flat` |
| `get_price` count/end_date | 日线 | tushare源 | count=10 | PASS | count/end_date 语义一致（各返回最近 10 根） | — | — | `test_get_price_count_and_end_date_semantics` |
| `get_price(fq="pre")` | 前复权跨分红 | tushare源 | `000001.XSHE` 跨 2024-06-14；`600519.XSHG` 跨 2025-06-26 | PASS | 跨分红窗口与基准最大偏差 0 | 双源均用原始价 + 远程 adj_factor 构造前复权 | — | `test_get_price_pre_across_dividend_window` |
| `get_price(fq="post")` | 后复权跨分红 | tushare源 | `000001.XSHE` 跨 2024-06-14 | PASS | 与基准一致（构造 factor 后锚定除权日） | — | — | `test_get_price_post_across_dividend_window` |
| `pre_factor_ref_date` | 动态前复权 | tushare源 | `600519.XSHG` 参考日 2025-03-15 / 2025-06-27（跨分红）/ 2025-07-15 | PASS | 多参考日与基准最大偏差 0 | `raw * factor / factor_ref` 锚定 | — | `test_get_price_dynamic_pre_factor_ref_date` |
| `fields=["factor"]` | 单独取 factor | tushare源 | `000001.XSHE` | FAIL | 双源均静默返回全 0 的假 factor，非真实复权因子 | 可改为走 `adj_factor` 返回真实因子，或显式 `NotImplementedError` | 静默假数据违反验收原则，需修复或降级后才可宣称支持 | `test_get_price_factor_field_behavior` |
| `get_price` 分钟线 | 近期 1m | tushare源 | `000001.XSHE` 2026-07-31 14:30~15:00 | LIMIT | `stk_mins` 限频(1次/分钟或1次/小时)或窗口无分钟数据 | 分钟线无本地存储，tushare_duckdb 构造上恒回退远程 `stk_mins`（离线单测已验证不短路） | token 权限限制，需更高积分 token 补测 | `test_get_price_minute_recent_window` |
| `get_trade_days` / `get_trade_day` | 交易日历 | tushare源 | 2024-Q1 | PASS | 集合、count=5、边界(元旦/周六)、get_trade_day 与基准一致 | 双源均走远程 trade_cal | — | `test_get_trade_days_and_day` |
| `get_all_securities` / `get_security_info` | 列表/信息 | tushare源 | 股票/ETF/指数样例 | PASS | schema、样例标的、聚宽代码格式一致；get_security_info 相等且类型正确 | 双源均走远程 stock_basic/fund_basic/index_basic | 全量列表以 tushare 快照为准，不宣称与 JQData 全量强一致 | `test_get_all_securities_and_info` |
| `get_split_dividend` | 分红除权 | tushare源 | `000001.XSHE` 2024~2025 | PASS | 事件字段、单位与基准一致，并通过复权闭环对账 | 双源均走远程 dividend/fund_div | 更多公司行为样例仍建议补充 | `test_get_split_dividend` |
| `get_bars` | 聚宽兼容 K 线 | tushare源 | — | UNSUPPORTED | provider 层与外层 `api.get_bars` 均稳定抛 `NotImplementedError` | 后续实现可包装 get_price 等价窗口/字段 | 如需聚宽 get_bars 语义需单独实现并验收 | `test_get_bars_not_implemented` + 离线用例 |
| `get_live_current` / `get_current_tick` | 实时快照 | tushare源 | `000001.XSHE` | LIMIT | `stk_mins` 限频或非交易时段无最新分钟；成功路径下 last_price 可用但 high_limit/low_limit 恒 0、paused 恒 False | 实时快照恒走远程 1min（无本地分钟表）；get_current_tick 未实现 | 实时数据不可回放；tushare 无免费实时接口 | `test_get_live_current_fields` |
| `get_index_stocks` / `get_index_weights` | 指数成分/权重 | tushare源 | `000300.XSHG` 2026-07-31 | LIMIT | `index_weight` 接口当前返回空（疑似免费 token 权限不足），双源行为一致 | 不把空列表解释为指数无成分 | 需有 index_weight 权限的 token 补测真实成分/权重 | `test_get_index_stocks_and_weights` |
| 扩展接口 | 财务/行业/概念/融资融券/期货 | — | — | UNSUPPORTED | get_extras/get_fundamentals/行业/概念/融资融券/期货等稳定抛 `NotImplementedError`（不静默返回假数据） | — | 如需支持需按基准单独验收 | `tests/unit/test_tushare_duckdb_failure_modes.py` |
| API 兼容 | history/attribute_history/get_current_data | tushare源 | `000001.XSHE` | PASS | 聚宽风格外层 API 经双源 shape 与字段一致；get_current_data 空容器可访问 | 外层 API 复用 get_price 路径 | get_current_data 在回测/live 上下文的完整行为未在此覆盖 | `test_jq_style_api_compat` |

## 不可比 / 受限函数说明

| 函数 | 原因 | 后续动作 |
| --- | --- | --- |
| `get_price` 分钟线 | tushare `stk_mins` 对当前 token 限频 1 次/分钟、且出现 1 次/小时的硬上限，无法稳定取数。tushare_duckdb 无本地分钟表，分钟线恒回退远程，构造上两源一致。 | 更高积分 token 补测；或用有分钟数据缓存的源验收 |
| `get_live_current` | 依赖 `stk_mins`，同样受限；且 tushare 无免费实时接口，涨跌停/停牌字段为占位值。 | 需要真实实时源（如 QMT/easy_tdx）时另行验收 |
| `get_index_stocks` / `get_index_weights` | `index_weight` 返回空，疑似免费 token 权限不足；空列表不解释为指数无成分。 | 有 index_weight 权限的 token 补测 |
| `fields=["factor"]` | 双源均静默返回全 0 假 factor，违反「不能静默返回假数据」原则。 | 修复（走 adj_factor 或显式 NotImplementedError）后复验 |
| `get_bars` / 扩展接口 | 未实现，稳定抛 `NotImplementedError`，符合验收要求。 | 如需支持按基准单独验收 |

## 失败/限制的影响范围

- **默认 provider / 回测**：无影响。日线、复权、交易日、证券列表、分红等回测核心路径在本地库覆盖区间内
  与 tushare 源精确一致；本地库未覆盖时自动回退远程，行为与原生 tushare 相同。
- **显式启用 tushare_duckdb 源**：受两个数据侧限制影响——
  1. **本地库滞后风险**：若本地库最近同步日早于远程最新交易日，`daily`/`fund_daily` 查到非空本地结果
     时**不会**回退远程补齐缺口，最近交易日可能缺失（当前库同步至 2026-07-31，与远程当日一致，
     无实际缺口；需保持同步频率或补一条「本地滞后即回退远程」的增强）。
  2. **分钟/实时/指数成分**：分钟与实时依赖远程 `stk_mins`（限频），指数成分依赖 `index_weight`（权限），
     均与原生 tushare 源同等受限，非 tushare_duckdb 特有。
- **实盘**：tushare 源本身不提供免费实时行情，实盘如需实时快照应使用 QMT/easy_tdx 等专用源；
  tushare_duckdb 仅用于历史行情本地加速。

## 复现命令

离线失败模式用例：

```bash
python -m pytest tests/unit/test_tushare_duckdb_failure_modes.py -m unit -q
```

在线验收用例（框架文档指定的临时环境变量）：

```bash
TUSHARE_TOKEN=<token> \
tushare_duckdb_path=/data/tushare_persistence/duckdb/tushare.duckdb \
python -m pytest tests/e2e/data/test_tushare_vs_tushare_duckdb_acceptance.py \
  -m "e2e and requires_network" -s
```

> 注：`stk_mins` 限频（1次/分钟、极端 1次/小时）会使分钟/实时用例被记为 LIMIT 并 skip，
> 属预期行为；不因限频导致失败。收尾用例 `test_acceptance_report_completeness` 会校验必测清单无遗漏
> 并打印验收表。
